### PR TITLE
Improve publish API

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,6 +50,11 @@ function getRepo(options) {
  * Push a git branch to a remote (pushes gh-pages by default).
  */
 exports.publish = function publish(basePath, config, done) {
+  if (typeof config === 'function') {
+    done = config;
+    config = {};
+  }
+
   var defaults = {
     add: false,
     git: 'git',


### PR DESCRIPTION
This pull request has a few changes:
- Base path is now a required parameter up front, with no default value.
- The options parameter is now optional, allowing the module to be used like this: `ghpages.publish(basePath, callback)`
- I've removed the JSDoc comments since the `publish` function is now variadic and I'm not sure it's worth the trouble. Happy to be convinced otherwise :)
