### PR TITLE
Added support for an array of srcs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,10 +83,15 @@ exports.publish = function publish(basePath, config, done) {
     return;
   }
 
-  var files = glob.sync(options.src, {
-    cwd: basePath,
-    dot: options.dotfiles
-  }).filter(function(file) {
+  // Adding support for array of src
+  var files = [].concat(options.src).reduce(function(cur, next){
+    return glob.sync(next, {
+      cwd: basePath,
+      dot: options.dotfiles
+    }).filter(function(file){
+      return cur.indexOf(file) < 0;
+    }).concat(cur);
+  }, []).filter(function(file) {
     return !fs.statSync(path.join(basePath, file)).isDirectory();
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-pages",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Publish to a gh-pages branch on GitHub (or any other branch on any other remote)",
   "keywords": [
     "git",
@@ -11,6 +11,9 @@
     "name": "Tim Schaub",
     "url": "http://tschaub.net/"
   },
+  "contributors": [
+    "Alan Hoffmeister <alanhoffmeister@gmail.com>"
+  ],
   "licenses": [
     {
       "type": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ The default options work for simple cases cases.  The options described below le
 
 
 #### <a id="optionssrc">options.src</a>
- * type: `string`
+ * type: `string` or `array`
  * default: `'**/*'`
 
 The [minimatch](https://github.com/isaacs/minimatch) pattern used to select which files should be published.


### PR DESCRIPTION
Now you can have an array of sources in the options.

```javascript
ghpages.publish(path.join(__dirname, 'build'), {
  src: ['build/*.js', 'app/*.js']
}, callback);
```