### PR TITLE
Fixed exceptions thrown from the user's callback being silently swallowed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -208,8 +208,8 @@ exports.publish = function publish(basePath, config, done) {
           error = new Error(
               'Unspecified error (run without silent option for detail)');
         }
-        done(error);
-      });
+        throw error;
+      }).done(done);
 };
 
 


### PR DESCRIPTION
Example

```js
ghpages.publish('dist', function (err) {
  if (err) throw err;
})
```

When `err` is not null:
- Behavior in version 0.2.0: the exception is silently swallowed and the program finishes normally without any error or warning. The outcome is the same if the silent option is enabled.
- Behavior with this PR: the exception is thrown and the program stops with the error message and stacktrace. If the silent option is enabled, the error message is *Unspecified error (run without silent option for detail)*, as expected.
