### PR TITLE
Do not check out a branch if we have it already

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -136,6 +136,11 @@ exports.publish = function publish(basePath, config, done) {
         return git.fetch(options.remote, options.clone);
       })
       .then(function() {
+        // don't check out if we have master already
+        if(options.branch === 'master') {
+          return Q.resolve();
+        }
+
         log('Checking out ' + options.remote + '/' +
             options.branch);
         return git.checkout(options.remote, options.branch,


### PR DESCRIPTION
Previously this would fail because `master` branch has been checked out already by default. No need to check out in that case.

Closes #14.