### PR TITLE
Make CLI exit with error if publishing fails

### DIFF
--- a/bin/gh-pages
+++ b/bin/gh-pages
@@ -27,6 +27,10 @@ ghpages.publish(path.join(process.cwd(), program.dist), {
   logger: function(message) {
     console.log(message);
   }
-}, function() {
+}, function(err) {
+  if (err != null) {
+    console.log(err)
+    return process.exit(1);
+  }
   console.log('Published');
 });


### PR DESCRIPTION
always handle error argument in a callback