### PR TITLE
Allow an array of src patterns to be provided

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 
 var Q = require('q');
 var wrench = require('wrench');
-var glob = require('glob');
+var globby = require('globby');
 
 var git = require('./git');
 
@@ -113,7 +113,7 @@ exports.publish = function publish(basePath, config, callback) {
     return;
   }
 
-  var files = glob.sync(options.src, {
+  var files = globby.sync(options.src, {
     cwd: basePath,
     dot: options.dotfiles
   }).filter(function(file) {
@@ -125,7 +125,7 @@ exports.publish = function publish(basePath, config, callback) {
     return;
   }
 
-  var only = glob.sync(options.only, {cwd: basePath});
+  var only = globby.sync(options.only, {cwd: basePath});
 
   git.exe(options.git);
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "async": "1.5.2",
     "commander": "2.9.0",
-    "glob": "~7.0.0",
+    "globby": "^4.0.0",
     "graceful-fs": "4.1.2",
     "q": "1.4.1",
     "q-io": "1.13.2",

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ If a `gh-pages` branch already exists, it will be updated with all commits from 
 **Note** that any files in the `gh-pages` branch that are *not* in the `src` files **will be removed**.  See the [`add` option](#optionsadd) if you don't want any of the existing files removed.
 
 
-### <a id="optionsbase">`basePath`</a>
+### <a id="basepath">`basePath`</a>
 * type: `string`
 
 The base directory for all source files (those listed in the `src` config property).
@@ -68,10 +68,10 @@ The default options work for simple cases cases.  The options described below le
 
 
 #### <a id="optionssrc">options.src</a>
- * type: `string`
+ * type: `string|Array<string>`
  * default: `'**/*'`
 
-The [minimatch](https://github.com/isaacs/minimatch) pattern used to select which files should be published.
+The [minimatch](https://github.com/isaacs/minimatch) pattern or array of patterns used to select which files should be published.
 
 
 #### <a id="optionsdotfiles">options.dotfiles</a>


### PR DESCRIPTION
With this change, `src` can be a single pattern or an array of patterns.

Fixes #29.