### PR TITLE
Expose a "remove" option to the CLI

### DIFF
--- a/bin/gh-pages
+++ b/bin/gh-pages
@@ -21,6 +21,9 @@ program
       'commit message', 'Updates')
   .option('-t, --dotfiles', 'Include dotfiles')
   .option('-a, --add', 'Only add, and never remove existing files.')
+  .option('-l, --only <pattern>',
+      'Only remove files that match the given pattern ' +
+      '(ignored if used together with --add).', '.')
   .option('-n, --no-push', 'Commit only (with no push)')
   .parse(process.argv);
 
@@ -32,6 +35,7 @@ ghpages.publish(path.join(process.cwd(), program.dist), {
   message: program.message,
   dotfiles: !!program.dotfiles,
   add: !!program.add,
+  only: program.only,
   remote: program.remote,
   push: !program.noPush,
   logger: function(message) {

--- a/bin/gh-pages
+++ b/bin/gh-pages
@@ -21,8 +21,8 @@ program
       'commit message', 'Updates')
   .option('-t, --dotfiles', 'Include dotfiles')
   .option('-a, --add', 'Only add, and never remove existing files.')
-  .option('-l, --only <pattern>',
-      'Only remove files that match the given pattern ' +
+  .option('-v, --remove <pattern>',
+      'Remove files that match the given pattern ' +
       '(ignored if used together with --add).', '.')
   .option('-n, --no-push', 'Commit only (with no push)')
   .parse(process.argv);
@@ -35,7 +35,7 @@ ghpages.publish(path.join(process.cwd(), program.dist), {
   message: program.message,
   dotfiles: !!program.dotfiles,
   add: !!program.add,
-  only: program.only,
+  only: program.remove,
   remote: program.remote,
   push: !program.noPush,
   logger: function(message) {


### PR DESCRIPTION
This exposes a `remove` option to the CLI.  If a pattern is provided, only the matching files will be removed from the existing `dist` directory.  To leave just a single file, pattern negation can be used.  E.g.

```
gh-pages --remove '!CNAME'
```

Fixes #74.