### PR TITLE
Use rimraf for cleaning

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ var path = require('path');
 var fs = require('fs');
 
 var Q = require('q');
-var wrench = require('wrench');
+var rimraf = require('rimraf');
 var globby = require('globby');
 
 var git = require('./git');
@@ -241,5 +241,5 @@ exports.publish = function publish(basePath, config, callback) {
  * Clean the cache directory.
  */
 exports.clean = function clean() {
-  wrench.rmdirSyncRecursive(getCacheDir(), true);
+  rimraf.sync(getCacheDir());
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "graceful-fs": "4.1.2",
     "q": "1.4.1",
     "q-io": "1.13.2",
-    "wrench": "1.5.8"
+    "rimraf": "^2.5.2"
   },
   "devDependencies": {
     "chai": "^3.4.1",


### PR DESCRIPTION
This uses `rimraf` instead of `wrench` for cleaning the cache directory.

Fixes #77.