### PR TITLE
Provision for root path when splitting

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -14,7 +14,7 @@ var uniqueDirs = exports.uniqueDirs = function(files) {
   var dirs = {};
   files.forEach(function(filepath) {
     var parts = path.dirname(filepath).split(path.sep);
-    var partial = parts[0];
+    var partial = parts[0] || '/';
     dirs[partial] = true;
     for (var i = 1, ii = parts.length; i < ii; ++i) {
       partial = path.join(partial, parts[i]);

--- a/test/lib/util.spec.js
+++ b/test/lib/util.spec.js
@@ -70,6 +70,29 @@ describe('util', function() {
       assert.deepEqual(got, expected);
     });
 
+    it('gets a list of unique directories on absolute paths', function() {
+      var absoluteFiles = files.map(function(path) { 
+        return '/' + path;
+      });
+      // not comparing order here, so we sort both
+      var got = util.uniqueDirs(absoluteFiles).sort();
+
+      var expected = [
+        '/',
+        '/a1',
+        '/a2',
+        path.join('/a1', 'b1'),
+        path.join('/a1', 'b1', 'c1'),
+        path.join('/a1', 'b1', 'c2'),
+        path.join('/a1', 'b2'),
+        path.join('/a1', 'b2', 'c1'),
+        path.join('/a1', 'b2', 'c2'),
+        path.join('/a2', 'b1')
+      ].sort();
+
+      assert.deepEqual(got, expected);
+    });
+
   });
 
   describe('dirsToCreate', function() {


### PR DESCRIPTION
When splitting an absolute path on `/` the first entry in the parts array will always be empty. It is more reasonable to be the root path though.

If it is an relative path the first entry of the array will always be truthy.

Closes #16 
