### PR TITLE
Publish branch to subfolder

### DIFF
--- a/bin/gh-pages
+++ b/bin/gh-pages
@@ -27,6 +27,8 @@ program
       'Remove files that match the given pattern ' +
       '(ignored if used together with --add).', '.')
   .option('-n, --no-push', 'Commit only (with no push)')
+  .option('-e, --dest <dest>', 'The destination in the target branch', '.')
+  .option('-c, --branchname-as-dest', 'Use a subfolder named after the current as the destination')
   .parse(process.argv);
 
 ghpages.publish(path.join(process.cwd(), program.dist), {
@@ -41,6 +43,8 @@ ghpages.publish(path.join(process.cwd(), program.dist), {
   only: program.remove,
   remote: program.remote,
   push: !program.noPush,
+  dest: program.dest,
+  branchnameAsDest: program.branchnameAsDest,
   logger: function(message) {
     process.stderr.write(message + '\n');
   }

--- a/lib/git.js
+++ b/lib/git.js
@@ -206,7 +206,7 @@ exports.add = function add(files, cwd) {
  * @return {Promise} A promise.
  */
 exports.commit = function commit(message, cwd) {
-  return spawn(git, ['diff-index', '--quiet', 'HEAD', '.'], cwd)
+  return spawn(git, ['diff-index', '--quiet', 'HEAD', '--', '.'], cwd)
       .then(function() {
         // nothing to commit
         return Q.resolve();

--- a/lib/index.js
+++ b/lib/index.js
@@ -111,7 +111,7 @@ exports.publish = function publish(basePath, config, callback) {
   for (var c in config) {
     options[c] = config[c];
   }
-console.log(options);
+
   function log(message) {
     if (!options.silent) {
       options.logger(message);
@@ -212,9 +212,8 @@ console.log(options);
       .then(function() {
         if (!options.add) {
           log('Removing files');
-          var dest = options.branchNameAsDest
           var outputFiles = only.map(function(file) {
-            return path.join(options.dest, file);
+            return path.join(dest, file);
           });
           return git.rm(outputFiles.join(' '), options.clone);
         } else {
@@ -223,7 +222,7 @@ console.log(options);
       })
       .then(function() {
         log('Copying files');
-        return copy(files, basePath, path.join(options.clone, options.dest));
+        return copy(files, basePath, path.join(options.clone, dest));
       })
       .then(function() {
         log('Adding all');

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,35 @@ function getRemoteUrl(dir, remote) {
       });
 }
 
+
+/**
+ * Return a promise resolving to the currently checked out branch name.
+ * @param {string} cwd Repository directory.
+ * @return {Promise} A promise.
+ */
+function getBranchName(options) {
+  var name;
+  return git(['rev-parse', '--abbrev-ref', 'HEAD'], options.repo || process.cwd())
+      .progress(function(chunk) {
+        name = String(chunk).split(/[\n\r]/).shift();
+      })
+      .then(function() {
+        if (name) {
+          return Q.resolve(name);
+        } else {
+          return Q.reject(new Error(
+            'Failed to get branch name from options or current directory.'));
+        }
+      })
+      .fail(function(err) {
+        return Q.reject(new Error(
+            'Failed to get branch name (task must either be ' +
+            'run in a git repository or must be configured with the "repo" ' +
+            'option).'));
+      });
+};
+
+
 function getRepo(options) {
   if (options.repo) {
     return Q.resolve(options.repo);
@@ -58,6 +87,7 @@ exports.publish = function publish(basePath, config, callback) {
 
   var defaults = {
     dest: '.',
+    branchnameAsDest: false,
     add: false,
     git: 'git',
     clone: getCacheDir(),
@@ -81,7 +111,7 @@ exports.publish = function publish(basePath, config, callback) {
   for (var c in config) {
     options[c] = config[c];
   }
-
+console.log(options);
   function log(message) {
     if (!options.silent) {
       options.logger(message);
@@ -130,12 +160,25 @@ exports.publish = function publish(basePath, config, callback) {
 
   git.exe(options.git);
 
+  var dest = options.dest
+
   var repoUrl;
   getRepo(options)
       .then(function(repo) {
         repoUrl = repo;
         log('Cloning ' + repo + ' into ' + options.clone);
         return git.clone(repo, options.clone, options.branch, options);
+      })
+      .then(function() {
+        if (options.branchnameAsDest) {
+          log('Retrieving current branch name');
+          return getBranchName(options.clone)
+            .then(function(branchname) {
+              dest = './' + branchname;
+            });
+        } else {
+          return Q.resolve();
+        }
       })
       .then(function() {
         return getRemoteUrl(options.clone, options.remote)
@@ -169,6 +212,7 @@ exports.publish = function publish(basePath, config, callback) {
       .then(function() {
         if (!options.add) {
           log('Removing files');
+          var dest = options.branchNameAsDest
           var outputFiles = only.map(function(file) {
             return path.join(options.dest, file);
           });

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ function getRemoteUrl(dir, remote) {
 
 /**
  * Return a promise resolving to the currently checked out branch name.
- * @param {string} cwd Repository directory.
+ * @param {Object} options The options object
  * @return {Promise} A promise.
  */
 function getBranchName(options) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ function getBranchName(options) {
             'run in a git repository or must be configured with the "repo" ' +
             'option).'));
       });
-};
+}
 
 
 function getRepo(options) {
@@ -160,7 +160,7 @@ exports.publish = function publish(basePath, config, callback) {
 
   git.exe(options.git);
 
-  var dest = options.dest
+  var dest = options.dest;
 
   var repoUrl;
   getRepo(options)

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,7 @@ exports.publish = function publish(basePath, config, callback) {
   }
 
   var defaults = {
+    dest: '.',
     add: false,
     git: 'git',
     clone: getCacheDir(),
@@ -168,14 +169,17 @@ exports.publish = function publish(basePath, config, callback) {
       .then(function() {
         if (!options.add) {
           log('Removing files');
-          return git.rm(only.join(' '), options.clone);
+          var outputFiles = only.map(function(file) {
+            return path.join(options.dest, file);
+          });
+          return git.rm(outputFiles.join(' '), options.clone);
         } else {
           return Q.resolve();
         }
       })
       .then(function() {
         log('Copying files');
-        return copy(files, basePath, options.clone);
+        return copy(files, basePath, path.join(options.clone, options.dest));
       })
       .then(function() {
         log('Adding all');

--- a/readme.md
+++ b/readme.md
@@ -317,6 +317,19 @@ ghpages.publish(path.join(__dirname, 'build'), {
 }, callback);
 ```
 
+#### <a id="optionsdest">options.branchnameAsDest</a>
+ * type: `boolean`
+ * default: `false`
+
+Use the current branch name as the path to the destination folder within the destination branch/repository. This option overrides the `dest` option.
+
+Example use of the `dest` option:
+
+```js
+ghpages.publish(path.join(__dirname, 'build'), { branchnameAsDest: true }, callback);
+```
+
+
 ## Command Line Utility
 
 Installing the package creates a `gh-pages` command line utility.  Run `gh-pages --help` to see a list of supported options.

--- a/readme.md
+++ b/readme.md
@@ -299,6 +299,24 @@ ghpages.publish(path.join(__dirname, 'build'), {
 }, callback);
 ```
 
+#### <a id="optionsdest">options.dest</a>
+ * type: `string`
+ * default: `'.'`
+
+The destination folder within the destination branch/repository.
+
+Example use of the `dest` option:
+
+```js
+/**
+ * Place content in the static/project subdirectory of the target
+ * branch/repository. If removing files, only remove static/project.
+ */
+ghpages.publish(path.join(__dirname, 'build'), {
+  dest: 'static/project'
+}, callback);
+```
+
 ## Command Line Utility
 
 Installing the package creates a `gh-pages` command line utility.  Run `gh-pages --help` to see a list of supported options.


### PR DESCRIPTION
This PR includes https://github.com/tschaub/gh-pages/pull/30 and adds yet another feature on top of it:

When the new option `branchnameAsDest` is set to true, the script will determine the name of the currently checked out branch and set this as the destination path in the target branch. This is useful for continuos integration scenarios when you want to have a pages version published for each open PR.