### PR TITLE
Update `q-io` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "globby": "^6.1.0",
     "graceful-fs": "4.1.10",
     "q": "1.4.1",
-    "q-io": "1.13.2",
+    "q-io": "2.0.6",
     "rimraf": "^2.5.4"
   },
   "devDependencies": {


### PR DESCRIPTION
q-io depends on `collections`

as mentioned in issue #42, collections breaks some other libraries
because it modifies Array.prototype

this was corrected in 2.0.1 of collections and the dependency
is updated in v2 of q-io