### PR TITLE
Clone with depth 1 by default

### DIFF
--- a/bin/gh-pages
+++ b/bin/gh-pages
@@ -22,6 +22,7 @@ program
   .option('-o, --remote <name>', 'The name of the remote', 'origin')
   .option('-m, --message <message>', 'commit message', 'Updates')
   .option('-g, --tag <tag>', 'add tag to commit')
+  .option('-p, --depth <depth>', 'depth for clone', 1)
   .option('-t, --dotfiles', 'Include dotfiles')
   .option('-a, --add', 'Only add, and never remove existing files.')
   .option(

--- a/lib/git.js
+++ b/lib/git.js
@@ -96,11 +96,10 @@ exports.clone = function clone(repo, dir, branch, options) {
           branch,
           '--single-branch',
           '--origin',
-          options.remote
+          options.remote,
+          '--depth',
+          options.depth
         ];
-        if (options.depth) {
-          args.push('--depth', options.depth);
-        }
         return spawn(git, args).catch(function(err) {
           // try again without banch options
           return spawn(git, ['clone', repo, dir, '--origin', options.remote]);

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,6 +58,7 @@ exports.publish = function publish(basePath, config, callback) {
     add: false,
     git: 'git',
     clone: getCacheDir(),
+    depth: 1,
     dotfiles: false,
     branch: 'gh-pages',
     remote: 'origin',


### PR DESCRIPTION
This is an alternative to #162.  This exposes the `depth` to the CLI and makes the default `1`.