### PR TITLE
Remove the logger option and use util.debuglog()

### DIFF
--- a/bin/gh-pages
+++ b/bin/gh-pages
@@ -55,10 +55,7 @@ function main(args) {
       add: !!program.add,
       only: program.remove,
       remote: program.remote,
-      push: !!program.push,
-      logger: function(message) {
-        process.stderr.write(message + '\n');
-      }
+      push: !!program.push
     },
     function(err) {
       if (err) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,12 @@
+var Git = require('./git');
+var base64url = require('base64url');
 var copy = require('./util').copy;
 var fs = require('fs-extra');
-var Git = require('./git');
 var globby = require('globby');
 var path = require('path');
-var base64url = require('base64url');
+var util = require('util');
+
+var log = util.debuglog('gh-pages');
 
 function getCacheDir() {
   return path.relative(process.cwd(), path.resolve(__dirname, '../.cache'));
@@ -42,17 +45,10 @@ exports.publish = function publish(basePath, config, callback) {
     only: '.',
     push: true,
     message: 'Updates',
-    silent: false,
-    logger: function() {}
+    silent: false
   };
 
   var options = Object.assign({}, defaults, config);
-
-  function log(message) {
-    if (!options.silent) {
-      options.logger(message);
-    }
-  }
 
   if (!callback) {
     callback = function(err) {
@@ -66,7 +62,7 @@ exports.publish = function publish(basePath, config, callback) {
     try {
       callback(err);
     } catch (err2) {
-      log('Publish callback threw: ', err2.message);
+      log('Publish callback threw: %s', err2.message);
     }
   }
 
@@ -108,7 +104,7 @@ exports.publish = function publish(basePath, config, callback) {
       if (!clone) {
         clone = path.join(getCacheDir(), base64url(repo));
       }
-      log('Cloning ' + repo + ' into ' + clone);
+      log('Cloning %s into %s', repo, clone);
       return Git.clone(repo, clone, options.branch, options);
     })
     .then(function(git) {
@@ -134,11 +130,11 @@ exports.publish = function publish(basePath, config, callback) {
       return git.clean();
     })
     .then(function(git) {
-      log('Fetching ' + options.remote);
+      log('Fetching %s', options.remote);
       return git.fetch(options.remote);
     })
     .then(function(git) {
-      log('Checking out ' + options.remote + '/' + options.branch);
+      log('Checking out %s/%s ', options.remote, options.branch);
       return git.checkout(options.remote, options.branch);
     })
     .then(function(git) {
@@ -183,8 +179,8 @@ exports.publish = function publish(basePath, config, callback) {
         log('Tagging');
         return git.tag(options.tag).catch(function(error) {
           // tagging failed probably because this tag alredy exists
+          log(error);
           log('Tagging failed, continuing');
-          options.logger(error);
           return git;
         });
       } else {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,12 @@
     "url": "https://github.com/tschaub/gh-pages/issues"
   },
   "main": "lib/index.js",
+  "config": {
+    "js": "lib test bin plugin.js"
+  },
   "scripts": {
-    "fix-lint": "eslint --fix lib test bin",
-    "pretest": "eslint lib test bin",
+    "fix-lint": "eslint --fix $npm_package_config_js",
+    "pretest": "eslint $npm_package_config_js",
     "test": "mocha --recursive test"
   },
   "engines": {

--- a/plugin.js
+++ b/plugin.js
@@ -1,6 +1,6 @@
-var ghPages = require('./lib/index')
-var path = require('path')
+var ghPages = require('./lib/index');
+var path = require('path');
 
-module.exports = function (pluginConfig, config, callback) {
-  ghPages.publish(path.join(process.cwd(), config.basePath), config, callback)
-}
+module.exports = function(pluginConfig, config, callback) {
+  ghPages.publish(path.join(process.cwd(), config.basePath), config, callback);
+};

--- a/readme.md
+++ b/readme.md
@@ -264,26 +264,6 @@ ghpages.publish(path.join(__dirname, 'build'), {
 ```
 
 
-#### <a id="optionslogger">options.logger</a>
- * type: `function(string)`
- * default: `function(){}`
-
-Logger function.  The default logging function is a no-op, allowing you to provide a custom logging implementation.
-
-Example use of the `logger` option:
-
-```js
-/**
- * This configuration will log to the console
- */
-ghpages.publish(path.join(__dirname, 'build'), {
-  logger: function(message) {
-    console.log(message);
-  }
-}, callback);
-```
-
-
 #### <a id="optionsgit">options.git</a>
  * type: `string`
  * default: `'git'`
@@ -335,6 +315,14 @@ And then to publish everything from your `dist` folder to your `gh-pages` branch
 
 ```shell
 npm run deploy
+```
+
+## Debugging
+
+To get additional output from the `gh-pages` script, set `NODE_DEBUG=gh-pages`.  For example:
+
+```shell
+NODE_DEBUG=gh-pages npm run deploy
 ```
 
 ## Dependencies


### PR DESCRIPTION
To debug the `gh-pages` script, set `NODE_DEBUG=gh-pages`.
