### PR TITLE
Feature: append cache to options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,9 +7,13 @@ var path = require('path');
 var util = require('util');
 
 var log = util.debuglog('gh-pages');
+var _CACHE_PATH = path.resolve(__dirname, '../.cache');
 
-function getCacheDir() {
-  return path.relative(process.cwd(), path.resolve(__dirname, '../.cache'));
+function getCacheDir(cachePath = _CACHE_PATH) {
+  if (_CACHE_PATH !== cachePath) {
+    _CACHE_PATH = cachePath;
+  }
+  return path.relative(process.cwd(), cachePath);
 }
 
 function getRepo(options) {
@@ -45,7 +49,8 @@ exports.publish = function publish(basePath, config, callback) {
     only: '.',
     push: true,
     message: 'Updates',
-    silent: false
+    silent: false,
+    cache: _CACHE_PATH
   };
 
   var options = Object.assign({}, defaults, config);
@@ -102,7 +107,7 @@ exports.publish = function publish(basePath, config, callback) {
       repoUrl = repo;
       var clone = options.clone;
       if (!clone) {
-        clone = path.join(getCacheDir(), base64url(repo));
+        clone = path.join(getCacheDir(options.cache), base64url(repo));
       }
       log('Cloning %s into %s', repo, clone);
       return Git.clone(repo, clone, options.branch, options);

--- a/readme.md
+++ b/readme.md
@@ -294,6 +294,23 @@ Example use of the `git` option:
 ghpages.publish('dist', {
   git: '/path/to/git'
 }, callback);
+```  
+
+#### <a id="optionscache">options.cache</a>
+ * type: `string`
+ * default: `path.resolve(__dirname, '../.cache')`
+
+When global installation, manually specifying cache locations can avoid most permissions errors.
+
+Example use of the `cache` option:
+
+```js
+/**
+ * If you need a new cache path.
+ */
+ghpages.publish('dist', {
+  cache: path.resolve(__dirname, './temp/cache')
+}, callback);
 ```
 
 ## Command Line Utility


### PR DESCRIPTION
when I install gh-pages in global, or when I depend on this library, the cache folder will write permission errors.
i added an optional option about cache path.

