### PR TITLE
A suspicious testing for "options" / problem of helper.setupRemote invocations

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -43,7 +43,7 @@ function setupRemote(fixtureName, options) {
   options = options || {};
   var branch = options.branch || 'gh-pages';
   var userEmail = (options.user && options.user.email) || 'user@email.com';
-  var userName = (options.name && options.user.name) || 'User Name';
+  var userName = (options.user && options.user.name) || 'User Name';
   return mkdtemp()
     .then(function(remote) {
       return new Git(remote).exec('init', '--bare').then(relay(remote));

--- a/test/integration/basic.spec.js
+++ b/test/integration/basic.spec.js
@@ -15,7 +15,7 @@ describe('basic usage', function() {
     var expected = path.join(fixtures, fixtureName, 'expected');
     var branch = 'gh-pages';
 
-    helper.setupRemote(fixtureName, branch).then(function(url) {
+    helper.setupRemote(fixtureName, {branch: branch}).then(function(url) {
       var options = {
         repo: url,
         user: {
@@ -41,7 +41,7 @@ describe('basic usage', function() {
     var local = path.join(fixtures, fixtureName, 'local');
     var branch = 'master';
 
-    helper.setupRemote(fixtureName, branch).then(function(url) {
+    helper.setupRemote(fixtureName, {branch: branch}).then(function(url) {
       var options = {
         repo: url,
         branch: branch,

--- a/test/integration/dest.spec.js
+++ b/test/integration/dest.spec.js
@@ -16,7 +16,7 @@ describe('the dest option', function() {
     var branch = 'gh-pages';
     var dest = 'target';
 
-    helper.setupRemote(fixtureName, branch).then(function(url) {
+    helper.setupRemote(fixtureName, {branch: branch}).then(function(url) {
       var options = {
         repo: url,
         dest: dest,

--- a/test/integration/include.spec.js
+++ b/test/integration/include.spec.js
@@ -15,7 +15,7 @@ describe('the src option', function() {
     var expected = path.join(fixtures, fixtureName, 'expected');
     var branch = 'gh-pages';
 
-    helper.setupRemote(fixtureName, branch).then(function(url) {
+    helper.setupRemote(fixtureName, {branch: branch}).then(function(url) {
       var options = {
         repo: url,
         src: '**/*.js',


### PR DESCRIPTION
Delighted, this is my first participating for your project.

In `setupRemote` of `test/helper.js`, it seems that there is a wrong testing for `options`.

Furthermore, *all* invocations of `helper.setupRemote` function are passing `string` (branch name) as a second argument while the function expects an `object` (options).
I fixed them as well.

If you consider that my fixing for each `setupRemote` invocation is not necessary, reject this request.
Nevertheless, maybe some correction for them should be made. 