### PR TITLE
Better user handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 
 language: node_js
 node_js:
+  - "6"
   - "8"
   - "10"
 

--- a/bin/gh-pages.js
+++ b/bin/gh-pages.js
@@ -5,69 +5,90 @@ const Git = require('../lib/git');
 const program = require('commander');
 const path = require('path');
 const pkg = require('../package.json');
+const addr = require('email-addresses');
+
+function publish(config) {
+  return new Promise((resolve, reject) => {
+    const basePath = path.join(process.cwd(), program.dist);
+    ghpages.publish(basePath, config, err => {
+      if (err) {
+        return reject(err);
+      }
+      resolve();
+    });
+  });
+}
+
+function getUser(cwd) {
+  return Promise.all([
+    new Git(cwd).exec('config', 'user.name'),
+    new Git(cwd).exec('config', 'user.email')
+  ])
+    .then(results => {
+      return {name: results[0].output.trim(), email: results[1].output.trim()};
+    })
+    .catch(err => {
+      // git config exits with 1 if name or email is not set
+      return null;
+    });
+}
 
 function main(args) {
-  program
-    .version(pkg.version)
-    .option('-d, --dist <dist>', 'Base directory for all source files')
-    .option(
-      '-s, --src <src>',
-      'Pattern used to select which files to publish',
-      '**/*'
-    )
-    .option(
-      '-b, --branch <branch>',
-      'Name of the branch you are pushing to',
-      'gh-pages'
-    )
-    .option(
-      '-e, --dest <dest>',
-      'Target directory within the destination branch (relative to the root)',
-      '.'
-    )
-    .option('-a, --add', 'Only add, and never remove existing files')
-    .option('-x, --silent', 'Do not output the repository url')
-    .option('-m, --message <message>', 'commit message', 'Updates')
-    .option('-g, --tag <tag>', 'add tag to commit')
-    .option('-t, --dotfiles', 'Include dotfiles')
-    .option('-r, --repo <repo>', 'URL of the repository you are pushing to')
-    .option('-p, --depth <depth>', 'depth for clone', 1)
-    .option('-o, --remote <name>', 'The name of the remote', 'origin')
-    .option(
-      '-v, --remove <pattern>',
-      'Remove files that match the given pattern ' +
-        '(ignored if used together with --add).',
-      '.'
-    )
-    .option('-n, --no-push', 'Commit only (with no push)')
-    .option('-l, --localuser', 'Use Git local user config (not global)')
-    .option('-u, --user <username,email>', 'Override default username, email')
-    .parse(args);
+  return Promise.resolve().then(() => {
+    program
+      .version(pkg.version)
+      .option('-d, --dist <dist>', 'Base directory for all source files')
+      .option(
+        '-s, --src <src>',
+        'Pattern used to select which files to publish',
+        '**/*'
+      )
+      .option(
+        '-b, --branch <branch>',
+        'Name of the branch you are pushing to',
+        'gh-pages'
+      )
+      .option(
+        '-e, --dest <dest>',
+        'Target directory within the destination branch (relative to the root)',
+        '.'
+      )
+      .option('-a, --add', 'Only add, and never remove existing files')
+      .option('-x, --silent', 'Do not output the repository url')
+      .option('-m, --message <message>', 'commit message', 'Updates')
+      .option('-g, --tag <tag>', 'add tag to commit')
+      .option('-t, --dotfiles', 'Include dotfiles')
+      .option('-r, --repo <repo>', 'URL of the repository you are pushing to')
+      .option('-p, --depth <depth>', 'depth for clone', 1)
+      .option('-o, --remote <name>', 'The name of the remote', 'origin')
+      .option(
+        '-u, --user <address>',
+        'The name and email of the user (defaults to the git config).  Format is "Your Name <email@example.com>".'
+      )
+      .option(
+        '-v, --remove <pattern>',
+        'Remove files that match the given pattern ' +
+          '(ignored if used together with --add).',
+        '.'
+      )
+      .option('-n, --no-push', 'Commit only (with no push)')
+      .parse(args);
 
-  if (program.localuser) {
-    Promise.all([
-      new Git().exec('config', '--local', 'user.name'),
-      new Git().exec('config', '--local', 'user.email')
-    ]).then(results => {
-      publish({
-        name: results[0].output.trim(),
-        email: results[1].output.trim()
-      });
-    });
-  } else if (program.user) {
-    const userParts = program.user.split(',');
-    publish({
-      name: userParts[0],
-      email: userParts[1]
-    });
-  } else {
-    publish();
-  }
+    let userPromise;
+    if (program.user) {
+      const parts = addr.parseOneAddress(program.user);
+      if (!parts) {
+        throw new Error(
+          'Could not parse "Full Name <email@example.com>" from ' + program.user
+        );
+      }
+      userPromise = Promise.resolve({name: parts.name, email: parts.address});
+    } else {
+      userPromise = getUser();
+    }
 
-  function publish(user) {
-    ghpages.publish(
-      path.join(process.cwd(), program.dist),
-      {
+    return userPromise.then(user => {
+      const config = {
         repo: program.repo,
         silent: !!program.silent,
         branch: program.branch,
@@ -81,20 +102,22 @@ function main(args) {
         remote: program.remote,
         push: !!program.push,
         user: user
-      },
-      function(err) {
-        if (err) {
-          process.stderr.write(err.message + '\n');
-          return process.exit(1);
-        }
-        process.stderr.write('Published\n');
-      }
-    );
-  }
+      };
+
+      return publish(config);
+    });
+  });
 }
 
 if (require.main === module) {
-  main(process.argv);
+  main(process.argv)
+    .then(() => {
+      process.stdout.write('Published\n');
+    })
+    .catch(err => {
+      process.stderr.write(err.message, () => process.exit(1));
+    });
 }
 
-module.exports = main;
+exports = module.exports = main;
+exports.getUser = getUser;

--- a/bin/gh-pages.js
+++ b/bin/gh-pages.js
@@ -57,7 +57,7 @@ function main(args) {
   } else if (program.user) {
     const userParts = program.user.split(',');
     publish({
-      user: userParts[0],
+      name: userParts[0],
       email: userParts[1]
     });
   } else {

--- a/lib/git.js
+++ b/lib/git.js
@@ -66,17 +66,15 @@ function Git(cwd, cmd) {
  *     or rejected with an error.
  */
 Git.prototype.exec = function() {
-  return spawn(this.cmd, [].slice.call(arguments), this.cwd).then(
-    function(output) {
-      this.output = output;
-      return this;
-    }.bind(this)
-  );
+  return spawn(this.cmd, [].slice.call(arguments), this.cwd).then(output => {
+    this.output = output;
+    return this;
+  });
 };
 
 /**
  * Initialize repository.
- * @return {ChildProcess} Child process.
+ * @return {Promise} A promise.
  */
 Git.prototype.init = function() {
   return this.exec('init');
@@ -118,21 +116,13 @@ Git.prototype.fetch = function(remote) {
 Git.prototype.checkout = function(remote, branch) {
   const treeish = remote + '/' + branch;
   return this.exec('ls-remote', '--exit-code', '.', treeish).then(
-    function() {
+    () => {
       // branch exists on remote, hard reset
       return this.exec('checkout', branch)
-        .then(
-          function() {
-            return this.clean();
-          }.bind(this)
-        )
-        .then(
-          function() {
-            return this.reset(remote, branch);
-          }.bind(this)
-        );
-    }.bind(this),
-    function(error) {
+        .then(() => this.clean())
+        .then(() => this.reset(remote, branch));
+    },
+    error => {
       if (error instanceof ProcessError && error.code === 2) {
         // branch doesn't exist, create an orphan
         return this.exec('checkout', '--orphan', branch);
@@ -140,7 +130,7 @@ Git.prototype.checkout = function(remote, branch) {
         // unhandled error
         throw error;
       }
-    }.bind(this)
+    }
   );
 };
 
@@ -168,10 +158,8 @@ Git.prototype.add = function(files) {
  * @return {Promise} A promise.
  */
 Git.prototype.commit = function(message) {
-  return this.exec('diff-index', '--quiet', 'HEAD').catch(
-    function() {
-      return this.exec('commit', '-m', message);
-    }.bind(this)
+  return this.exec('diff-index', '--quiet', 'HEAD').catch(() =>
+    this.exec('commit', '-m', message)
   );
 };
 
@@ -201,7 +189,7 @@ Git.prototype.push = function(remote, branch) {
  */
 Git.prototype.getRemoteUrl = function(remote) {
   return this.exec('config', '--get', 'remote.' + remote + '.url')
-    .then(function(git) {
+    .then(git => {
       const repo = git.output && git.output.split(/[\n\r]/).shift();
       if (repo) {
         return repo;
@@ -211,7 +199,7 @@ Git.prototype.getRemoteUrl = function(remote) {
         );
       }
     })
-    .catch(function(err) {
+    .catch(err => {
       throw new Error(
         'Failed to get remote.' +
           remote +
@@ -233,11 +221,11 @@ Git.prototype.getRemoteUrl = function(remote) {
  * @return {Promise<Git>} A promise.
  */
 Git.clone = function clone(repo, dir, branch, options) {
-  return fs.exists(dir).then(function(exists) {
+  return fs.exists(dir).then(exists => {
     if (exists) {
       return Promise.resolve(new Git(dir, options.git));
     } else {
-      return fs.mkdirp(path.dirname(path.resolve(dir))).then(function() {
+      return fs.mkdirp(path.dirname(path.resolve(dir))).then(() => {
         const args = [
           'clone',
           repo,
@@ -251,7 +239,7 @@ Git.clone = function clone(repo, dir, branch, options) {
           options.depth
         ];
         return spawn(options.git, args)
-          .catch(function(err) {
+          .catch(err => {
             // try again without banch or depth options
             return spawn(options.git, [
               'clone',
@@ -261,9 +249,7 @@ Git.clone = function clone(repo, dir, branch, options) {
               options.remote
             ]);
           })
-          .then(function() {
-            return new Git(dir, options.git);
-          });
+          .then(() => new Git(dir, options.git));
       });
     }
   });

--- a/lib/git.js
+++ b/lib/git.js
@@ -26,16 +26,16 @@ util.inherits(ProcessError, Error);
  * @return {Promise} A promise.
  */
 function spawn(exe, args, cwd) {
-  return new Promise(function(resolve, reject) {
+  return new Promise((resolve, reject) => {
     const child = cp.spawn(exe, args, {cwd: cwd || process.cwd()});
     const buffer = [];
-    child.stderr.on('data', function(chunk) {
+    child.stderr.on('data', chunk => {
       buffer.push(chunk.toString());
     });
-    child.stdout.on('data', function(chunk) {
+    child.stdout.on('data', chunk => {
       buffer.push(chunk.toString());
     });
-    child.on('close', function(code) {
+    child.on('close', code => {
       const output = buffer.join('');
       if (code) {
         const msg = output || 'Process failed: ' + code;

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,7 @@ exports.publish = function publish(basePath, config, callback) {
       cwd: basePath,
       dot: options.dotfiles
     })
-    .filter(function(file) {
+    .filter(file => {
       return !fs.statSync(path.join(basePath, file)).isDirectory();
     });
 
@@ -92,13 +92,13 @@ exports.publish = function publish(basePath, config, callback) {
     return;
   }
 
-  const only = globby.sync(options.only, {cwd: basePath}).map(function(file) {
+  const only = globby.sync(options.only, {cwd: basePath}).map(file => {
     return path.join(options.dest, file);
   });
 
   let repoUrl;
   return getRepo(options)
-    .then(function(repo) {
+    .then(repo => {
       repoUrl = repo;
       let clone = options.clone;
       if (!clone) {
@@ -107,8 +107,8 @@ exports.publish = function publish(basePath, config, callback) {
       log('Cloning %s into %s', repo, clone);
       return Git.clone(repo, clone, options.branch, options);
     })
-    .then(function(git) {
-      return git.getRemoteUrl(options.remote).then(function(url) {
+    .then(git => {
+      return git.getRemoteUrl(options.remote).then(url => {
         if (url !== repoUrl) {
           const message =
             'Remote url mismatch.  Got "' +
@@ -124,20 +124,20 @@ exports.publish = function publish(basePath, config, callback) {
         return git;
       });
     })
-    .then(function(git) {
+    .then(git => {
       // only required if someone mucks with the checkout between builds
       log('Cleaning');
       return git.clean();
     })
-    .then(function(git) {
+    .then(git => {
       log('Fetching %s', options.remote);
       return git.fetch(options.remote);
     })
-    .then(function(git) {
+    .then(git => {
       log('Checking out %s/%s ', options.remote, options.branch);
       return git.checkout(options.remote, options.branch);
     })
-    .then(function(git) {
+    .then(git => {
       if (!options.add) {
         log('Removing files');
         return git.rm(only.join(' '));
@@ -145,7 +145,7 @@ exports.publish = function publish(basePath, config, callback) {
         return git;
       }
     })
-    .then(function(git) {
+    .then(git => {
       log('Copying files');
       return copy(files, basePath, path.join(git.cwd, options.dest)).then(
         function() {
@@ -153,29 +153,27 @@ exports.publish = function publish(basePath, config, callback) {
         }
       );
     })
-    .then(function(git) {
+    .then(git => {
       log('Adding all');
       return git.add('.');
     })
-    .then(function(git) {
+    .then(git => {
       if (options.user) {
         return git
           .exec('config', 'user.email', options.user.email)
-          .then(function() {
-            return git.exec('config', 'user.name', options.user.name);
-          });
+          .then(() => git.exec('config', 'user.name', options.user.name));
       } else {
         return git;
       }
     })
-    .then(function(git) {
+    .then(git => {
       log('Committing');
       return git.commit(options.message);
     })
-    .then(function(git) {
+    .then(git => {
       if (options.tag) {
         log('Tagging');
-        return git.tag(options.tag).catch(function(error) {
+        return git.tag(options.tag).catch(error => {
           // tagging failed probably because this tag alredy exists
           log(error);
           log('Tagging failed, continuing');
@@ -185,7 +183,7 @@ exports.publish = function publish(basePath, config, callback) {
         return git;
       }
     })
-    .then(function(git) {
+    .then(git => {
       if (options.push) {
         log('Pushing');
         return git.push(options.remote, options.branch);
@@ -194,10 +192,8 @@ exports.publish = function publish(basePath, config, callback) {
       }
     })
     .then(
-      function() {
-        done();
-      },
-      function(error) {
+      () => done(),
+      error => {
         if (options.silent) {
           error = new Error(
             'Unspecified error (run without silent option for detail)'

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,7 @@
 const Git = require('./git');
 const filenamify = require('filenamify-url');
 const copy = require('./util').copy;
+const getUser = require('./util').getUser;
 const fs = require('fs-extra');
 const globby = require('globby');
 const path = require('path');
@@ -97,111 +98,115 @@ exports.publish = function publish(basePath, config, callback) {
   });
 
   let repoUrl;
-  return getRepo(options)
-    .then(repo => {
-      repoUrl = repo;
-      let clone = options.clone;
-      if (!clone) {
-        clone = path.join(getCacheDir(), filenamify(repo));
-      }
-      log('Cloning %s into %s', repo, clone);
-      return Git.clone(repo, clone, options.branch, options);
-    })
-    .then(git => {
-      return git.getRemoteUrl(options.remote).then(url => {
-        if (url !== repoUrl) {
-          const message =
-            'Remote url mismatch.  Got "' +
-            url +
-            '" ' +
-            'but expected "' +
-            repoUrl +
-            '" in ' +
-            git.cwd +
-            '.  Try running the `gh-pages-clean` script first.';
-          throw new Error(message);
-        }
-        return git;
-      });
-    })
-    .then(git => {
-      // only required if someone mucks with the checkout between builds
-      log('Cleaning');
-      return git.clean();
-    })
-    .then(git => {
-      log('Fetching %s', options.remote);
-      return git.fetch(options.remote);
-    })
-    .then(git => {
-      log('Checking out %s/%s ', options.remote, options.branch);
-      return git.checkout(options.remote, options.branch);
-    })
-    .then(git => {
-      if (!options.add) {
-        log('Removing files');
-        return git.rm(only.join(' '));
-      } else {
-        return git;
-      }
-    })
-    .then(git => {
-      log('Copying files');
-      return copy(files, basePath, path.join(git.cwd, options.dest)).then(
-        function() {
-          return git;
-        }
-      );
-    })
-    .then(git => {
-      log('Adding all');
-      return git.add('.');
-    })
-    .then(git => {
-      if (options.user) {
-        return git
-          .exec('config', 'user.email', options.user.email)
-          .then(() => git.exec('config', 'user.name', options.user.name));
-      } else {
-        return git;
-      }
-    })
-    .then(git => {
-      log('Committing');
-      return git.commit(options.message);
-    })
-    .then(git => {
-      if (options.tag) {
-        log('Tagging');
-        return git.tag(options.tag).catch(error => {
-          // tagging failed probably because this tag alredy exists
-          log(error);
-          log('Tagging failed, continuing');
+  let userPromise;
+  if (options.user) {
+    userPromise = Promise.resolve(options.user);
+  } else {
+    userPromise = getUser();
+  }
+  return userPromise.then(user =>
+    getRepo(options)
+      .then(repo => {
+        repoUrl = repo;
+        const clone = path.join(getCacheDir(), filenamify(repo));
+        log('Cloning %s into %s', repo, clone);
+        return Git.clone(repo, clone, options.branch, options);
+      })
+      .then(git => {
+        return git.getRemoteUrl(options.remote).then(url => {
+          if (url !== repoUrl) {
+            const message =
+              'Remote url mismatch.  Got "' +
+              url +
+              '" ' +
+              'but expected "' +
+              repoUrl +
+              '" in ' +
+              git.cwd +
+              '.  Try running the `gh-pages-clean` script first.';
+            throw new Error(message);
+          }
           return git;
         });
-      } else {
-        return git;
-      }
-    })
-    .then(git => {
-      if (options.push) {
-        log('Pushing');
-        return git.push(options.remote, options.branch);
-      } else {
-        return git;
-      }
-    })
-    .then(
-      () => done(),
-      error => {
-        if (options.silent) {
-          error = new Error(
-            'Unspecified error (run without silent option for detail)'
-          );
+      })
+      .then(git => {
+        // only required if someone mucks with the checkout between builds
+        log('Cleaning');
+        return git.clean();
+      })
+      .then(git => {
+        log('Fetching %s', options.remote);
+        return git.fetch(options.remote);
+      })
+      .then(git => {
+        log('Checking out %s/%s ', options.remote, options.branch);
+        return git.checkout(options.remote, options.branch);
+      })
+      .then(git => {
+        if (!options.add) {
+          log('Removing files');
+          return git.rm(only.join(' '));
+        } else {
+          return git;
         }
-        done(error);
-      }
-    );
+      })
+      .then(git => {
+        log('Copying files');
+        return copy(files, basePath, path.join(git.cwd, options.dest)).then(
+          function() {
+            return git;
+          }
+        );
+      })
+      .then(git => {
+        log('Adding all');
+        return git.add('.');
+      })
+      .then(git => {
+        return git.exec('config', 'user.email', user.email).then(() => {
+          if (!user.name) {
+            return git;
+          }
+          return git.exec('config', 'user.name', user.name);
+        });
+      })
+      .then(git => {
+        log('Committing');
+        return git.commit(options.message);
+      })
+      .then(git => {
+        if (options.tag) {
+          log('Tagging');
+          return git.tag(options.tag).catch(error => {
+            // tagging failed probably because this tag alredy exists
+            log(error);
+            log('Tagging failed, continuing');
+            return git;
+          });
+        } else {
+          return git;
+        }
+      })
+      .then(git => {
+        if (options.push) {
+          log('Pushing');
+          return git.push(options.remote, options.branch);
+        } else {
+          return git;
+        }
+      })
+      .then(
+        () => done(),
+        error => {
+          if (options.silent) {
+            error = new Error(
+              'Unspecified error (run without silent option for detail)'
+            );
+          }
+          done(error);
+        }
+      )
+  );
 };
 
 /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,5 +1,5 @@
 const path = require('path');
-
+const Git = require('./git');
 const async = require('async');
 const fs = require('graceful-fs');
 
@@ -152,4 +152,18 @@ exports.copy = function(files, base, dest) {
       });
     });
   });
+};
+
+exports.getUser = function(cwd) {
+  return Promise.all([
+    new Git(cwd).exec('config', 'user.name'),
+    new Git(cwd).exec('config', 'user.email')
+  ])
+    .then(results => {
+      return {name: results[0].output.trim(), email: results[1].output.trim()};
+    })
+    .catch(err => {
+      // git config exits with 1 if name or email is not set
+      return null;
+    });
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -10,7 +10,7 @@ const fs = require('graceful-fs');
  */
 const uniqueDirs = (exports.uniqueDirs = function(files) {
   const dirs = {};
-  files.forEach(function(filepath) {
+  files.forEach(filepath => {
     const parts = path.dirname(filepath).split(path.sep);
     let partial = parts[0] || '/';
     dirs[partial] = true;
@@ -29,7 +29,7 @@ const uniqueDirs = (exports.uniqueDirs = function(files) {
  * @param {string} b Second path.
  * @return {number} Comparison.
  */
-const byShortPath = (exports.byShortPath = function(a, b) {
+const byShortPath = (exports.byShortPath = (a, b) => {
   const aParts = a.split(path.sep);
   const bParts = b.split(path.sep);
   const aLength = aParts.length;
@@ -80,15 +80,15 @@ const copyFile = (exports.copyFile = function(obj, callback) {
   }
 
   const read = fs.createReadStream(obj.src);
-  read.on('error', function(err) {
+  read.on('error', err => {
     done(err);
   });
 
   const write = fs.createWriteStream(obj.dest);
-  write.on('error', function(err) {
+  write.on('error', err => {
     done(err);
   });
-  write.on('close', function(ex) {
+  write.on('close', () => {
     done();
   });
 
@@ -101,10 +101,10 @@ const copyFile = (exports.copyFile = function(obj, callback) {
  * @param {function(Error)} callback Callback.
  */
 function makeDir(path, callback) {
-  fs.mkdir(path, function(err) {
+  fs.mkdir(path, err => {
     if (err) {
       // check if directory exists
-      fs.stat(path, function(err2, stat) {
+      fs.stat(path, (err2, stat) => {
         if (err2 || !stat.isDirectory()) {
           callback(err);
         } else {
@@ -125,10 +125,10 @@ function makeDir(path, callback) {
  * @return {Promise} A promise.
  */
 exports.copy = function(files, base, dest) {
-  return new Promise(function(resolve, reject) {
+  return new Promise((resolve, reject) => {
     const pairs = [];
     const destFiles = [];
-    files.forEach(function(file) {
+    files.forEach(file => {
       const src = path.resolve(base, file);
       const relative = path.relative(base, src);
       const target = path.join(dest, relative);
@@ -139,11 +139,11 @@ exports.copy = function(files, base, dest) {
       destFiles.push(target);
     });
 
-    async.eachSeries(dirsToCreate(destFiles), makeDir, function(err) {
+    async.eachSeries(dirsToCreate(destFiles), makeDir, err => {
       if (err) {
         return reject(err);
       }
-      async.each(pairs, copyFile, function(err) {
+      async.each(pairs, copyFile, err => {
         if (err) {
           return reject(err);
         } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0"
+        "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/highlight": {
@@ -19,9 +19,9 @@
       "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
       "dev": true,
       "requires": {
-        "chalk": "2.4.1",
-        "esutils": "2.0.2",
-        "js-tokens": "4.0.0"
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
       }
     },
     "@sinonjs/commons": {
@@ -35,7 +35,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "dev": true,
       "requires": {
@@ -60,7 +60,7 @@
       "integrity": "sha512-JY+iV6r+cO21KtntVvFkD+iqjtdpRUpGqKWgfkCdZq1R+kbreEl8EcdcJR4SmiIgsIQT33s6QzheQ9a275Q8xw==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3"
+        "acorn": "^5.0.3"
       }
     },
     "ajv": {
@@ -69,10 +69,10 @@
       "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "2.0.1",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.4.1",
-        "uri-js": "4.2.2"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ajv-keywords": {
@@ -99,7 +99,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.3"
+        "color-convert": "^1.9.0"
       }
     },
     "argparse": {
@@ -108,7 +108,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "array-union": {
@@ -116,7 +116,7 @@
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -141,7 +141,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "4.17.10"
+        "lodash": "^4.17.10"
       }
     },
     "balanced-match": {
@@ -151,7 +151,7 @@
     },
     "bluebird": {
       "version": "3.4.1",
-      "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz",
       "integrity": "sha1-tzHd9I4t077awudeEhWhG8uR+gc=",
       "dev": true
     },
@@ -160,7 +160,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -188,7 +188,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -203,12 +203,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "check-error": "1.0.2",
-        "deep-eql": "3.0.1",
-        "get-func-name": "2.0.0",
-        "pathval": "1.1.0",
-        "type-detect": "4.0.8"
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
       }
     },
     "chalk": {
@@ -217,9 +217,9 @@
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.5.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
     },
     "chardet": {
@@ -246,7 +246,7 @@
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
       "dev": true,
       "requires": {
-        "restore-cursor": "2.0.0"
+        "restore-cursor": "^2.0.0"
       }
     },
     "cli-width": {
@@ -298,11 +298,11 @@
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "nice-try": "1.0.5",
-        "path-key": "2.0.1",
-        "semver": "5.5.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "debug": {
@@ -311,7 +311,7 @@
       "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
       "dev": true,
       "requires": {
-        "ms": "2.1.1"
+        "ms": "^2.1.1"
       }
     },
     "deep-eql": {
@@ -320,7 +320,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.8"
+        "type-detect": "^4.0.0"
       }
     },
     "deep-is": {
@@ -335,13 +335,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "globby": {
@@ -350,12 +350,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "arrify": "1.0.1",
-            "glob": "7.1.3",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "array-union": "^1.0.1",
+            "arrify": "^1.0.0",
+            "glob": "^7.0.3",
+            "object-assign": "^4.0.1",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -381,11 +381,11 @@
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "minimatch": {
@@ -394,7 +394,7 @@
           "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.0.0"
           }
         }
       }
@@ -405,8 +405,13 @@
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2"
+        "esutils": "^2.0.2"
       }
+    },
+    "email-addresses": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.0.1.tgz",
+      "integrity": "sha1-wfwgwYnn+W1AEtN121/qzN0kORw="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -414,7 +419,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "escape-string-regexp": {
@@ -428,44 +433,44 @@
       "integrity": "sha512-m+az4vYehIJgl1Z0gb25KnFXeqQRdNreYsei1jdvkd9bB+UNQD3fsuiC2AWSQ56P+/t++kFSINZXFbfai+krOw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0",
-        "ajv": "6.5.3",
-        "chalk": "2.4.1",
-        "cross-spawn": "6.0.5",
-        "debug": "3.2.5",
-        "doctrine": "2.1.0",
-        "eslint-scope": "4.0.0",
-        "eslint-utils": "1.3.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "4.0.0",
-        "esquery": "1.0.1",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.3",
-        "globals": "11.7.0",
-        "ignore": "4.0.6",
-        "imurmurhash": "0.1.4",
-        "inquirer": "6.2.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.12.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "regexpp": "2.0.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.5.1",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.3",
-        "text-table": "0.2.0"
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.5.3",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^3.1.0",
+        "doctrine": "^2.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^4.0.0",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.1.0",
+        "is-resolvable": "^1.1.0",
+        "js-yaml": "^3.12.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.5",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "pluralize": "^7.0.0",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.0",
+        "require-uncached": "^1.0.3",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^4.0.3",
+        "text-table": "^0.2.0"
       }
     },
     "eslint-config-prettier": {
@@ -474,7 +479,7 @@
       "integrity": "sha512-vA0TB8HCx/idHXfKHYcg9J98p0Q8nkfNwNAoP7e+ywUidn6ScaFS5iqncZAHPz+/a0A/tp657ulFHFx/2JDP4Q==",
       "dev": true,
       "requires": {
-        "get-stdin": "6.0.0"
+        "get-stdin": "^6.0.0"
       }
     },
     "eslint-config-tschaub": {
@@ -484,7 +489,7 @@
       "dev": true,
       "requires": {
         "eslint-config-prettier": "3.0.1",
-        "eslint-plugin-import": "2.14.0",
+        "eslint-plugin-import": "^2.14.0",
         "eslint-plugin-prettier": "2.6.2",
         "prettier": "1.14.2"
       }
@@ -495,8 +500,8 @@
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.8.1"
+        "debug": "^2.6.9",
+        "resolve": "^1.5.0"
       },
       "dependencies": {
         "debug": {
@@ -522,8 +527,8 @@
       "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "1.0.0"
+        "debug": "^2.6.8",
+        "pkg-dir": "^1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -549,16 +554,16 @@
       "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
       "dev": true,
       "requires": {
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.8",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.2.0",
-        "has": "1.0.3",
-        "lodash": "4.17.10",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0",
-        "resolve": "1.8.1"
+        "eslint-import-resolver-node": "^0.3.1",
+        "eslint-module-utils": "^2.2.0",
+        "has": "^1.0.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.3",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.6.0"
       },
       "dependencies": {
         "debug": {
@@ -576,8 +581,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         },
         "ms": {
@@ -594,8 +599,8 @@
       "integrity": "sha512-tGek5clmW5swrAx1mdPYM8oThrBE83ePh7LeseZHBWfHVGrHPhKn7Y5zgRMbU/9D5Td9K4CEmUPjGxA7iw98Og==",
       "dev": true,
       "requires": {
-        "fast-diff": "1.1.2",
-        "jest-docblock": "21.2.0"
+        "fast-diff": "^1.1.1",
+        "jest-docblock": "^21.0.0"
       }
     },
     "eslint-scope": {
@@ -604,8 +609,8 @@
       "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
       "dev": true,
       "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
@@ -626,8 +631,8 @@
       "integrity": "sha512-kapdTCt1bjmspxStVKX6huolXVV5ZfyZguY1lcfhVVZstce3bqxH9mcLzNn3/mlgW6wQ732+0fuG9v7h0ZQoKg==",
       "dev": true,
       "requires": {
-        "acorn": "5.7.3",
-        "acorn-jsx": "4.1.1"
+        "acorn": "^5.6.0",
+        "acorn-jsx": "^4.1.1"
       }
     },
     "esprima": {
@@ -642,7 +647,7 @@
       "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -651,7 +656,7 @@
       "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.1.0"
       }
     },
     "estraverse": {
@@ -672,9 +677,9 @@
       "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
       "dev": true,
       "requires": {
-        "chardet": "0.7.0",
-        "iconv-lite": "0.4.24",
-        "tmp": "0.0.33"
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
       }
     },
     "fast-deep-equal": {
@@ -707,7 +712,7 @@
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.5"
       }
     },
     "file-entry-cache": {
@@ -716,8 +721,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "filename-reserved-regex": {
@@ -730,9 +735,9 @@
       "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
       "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
       "requires": {
-        "filename-reserved-regex": "1.0.0",
-        "strip-outer": "1.0.1",
-        "trim-repeated": "1.0.0"
+        "filename-reserved-regex": "^1.0.0",
+        "strip-outer": "^1.0.0",
+        "trim-repeated": "^1.0.0"
       }
     },
     "filenamify-url": {
@@ -740,8 +745,8 @@
       "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
       "integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
       "requires": {
-        "filenamify": "1.2.1",
-        "humanize-url": "1.0.1"
+        "filenamify": "^1.0.0",
+        "humanize-url": "^1.0.0"
       }
     },
     "find-up": {
@@ -750,8 +755,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -760,10 +765,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "fs-extra": {
@@ -771,9 +776,9 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
       "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "4.0.0",
-        "universalify": "0.1.2"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -810,12 +815,12 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "globals": {
@@ -829,11 +834,11 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
       "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "requires": {
-        "array-union": "1.0.2",
-        "glob": "7.1.3",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -859,7 +864,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.1"
+        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
@@ -885,8 +890,8 @@
       "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
       "integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
       "requires": {
-        "normalize-url": "1.9.1",
-        "strip-url-auth": "1.0.1"
+        "normalize-url": "^1.0.0",
+        "strip-url-auth": "^1.0.0"
       }
     },
     "iconv-lite": {
@@ -895,7 +900,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
@@ -915,8 +920,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -930,19 +935,19 @@
       "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "3.0.3",
-        "figures": "2.0.0",
-        "lodash": "4.17.10",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.0",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.0",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.10",
         "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rxjs": "6.3.2",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
+        "run-async": "^2.2.0",
+        "rxjs": "^6.1.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^4.0.0",
+        "through": "^2.3.6"
       }
     },
     "is-arrayish": {
@@ -957,7 +962,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -978,7 +983,7 @@
       "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.1"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -987,7 +992,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-plain-obj": {
@@ -1037,8 +1042,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.1"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "json-schema-traverse": {
@@ -1058,7 +1063,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       }
     },
     "just-extend": {
@@ -1073,8 +1078,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -1083,10 +1088,10 @@
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "strip-bom": "3.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "strip-bom": "^3.0.0"
       }
     },
     "locate-path": {
@@ -1095,8 +1100,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       },
       "dependencies": {
         "path-exists": {
@@ -1135,18 +1140,18 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -1193,12 +1198,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "ms": {
@@ -1213,7 +1218,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -1248,11 +1253,11 @@
       "integrity": "sha512-pxE0c9PzgrUTyhfv5p+5eMIdfU2bLEsq8VQEuE0kxM4zP7SujSar7rk9wpI2F7RyyCEvLyj5O7Is3RER5F36Fg==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "just-extend": "3.0.0",
-        "lolex": "2.7.4",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
+        "@sinonjs/formatio": "^2.0.0",
+        "just-extend": "^3.0.0",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0",
+        "text-encoding": "^0.6.4"
       }
     },
     "normalize-package-data": {
@@ -1261,10 +1266,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.7.1",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.1",
-        "validate-npm-package-license": "3.0.4"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-url": {
@@ -1272,10 +1277,10 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "requires": {
-        "object-assign": "4.1.1",
-        "prepend-http": "1.0.4",
-        "query-string": "4.3.4",
-        "sort-keys": "1.1.2"
+        "object-assign": "^4.0.1",
+        "prepend-http": "^1.0.0",
+        "query-string": "^4.1.0",
+        "sort-keys": "^1.0.0"
       }
     },
     "object-assign": {
@@ -1288,7 +1293,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -1297,7 +1302,7 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.2.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "optionator": {
@@ -1306,12 +1311,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-tmpdir": {
@@ -1326,7 +1331,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "1.0.0"
+        "p-try": "^1.0.0"
       }
     },
     "p-locate": {
@@ -1335,7 +1340,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.3.0"
+        "p-limit": "^1.1.0"
       }
     },
     "p-try": {
@@ -1350,7 +1355,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.2"
+        "error-ex": "^1.2.0"
       }
     },
     "path-exists": {
@@ -1359,7 +1364,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -1408,7 +1413,7 @@
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
       "dev": true,
       "requires": {
-        "pify": "2.3.0"
+        "pify": "^2.0.0"
       }
     },
     "pathval": {
@@ -1432,7 +1437,7 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-dir": {
@@ -1441,7 +1446,7 @@
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "pluralize": {
@@ -1484,8 +1489,8 @@
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
       "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
       "requires": {
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
       }
     },
     "read-pkg": {
@@ -1494,9 +1499,9 @@
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
       "dev": true,
       "requires": {
-        "load-json-file": "2.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "2.0.0"
+        "load-json-file": "^2.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^2.0.0"
       }
     },
     "read-pkg-up": {
@@ -1505,8 +1510,8 @@
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
+        "find-up": "^2.0.0",
+        "read-pkg": "^2.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -1515,7 +1520,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "2.0.0"
+            "locate-path": "^2.0.0"
           }
         }
       }
@@ -1532,8 +1537,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
@@ -1542,7 +1547,7 @@
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.6"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -1557,8 +1562,8 @@
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
       "dev": true,
       "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
       }
     },
     "rimraf": {
@@ -1566,7 +1571,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.0.5"
       }
     },
     "run-async": {
@@ -1575,7 +1580,7 @@
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
-        "is-promise": "2.1.0"
+        "is-promise": "^2.1.0"
       }
     },
     "rxjs": {
@@ -1584,7 +1589,7 @@
       "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.3"
+        "tslib": "^1.9.0"
       }
     },
     "safer-buffer": {
@@ -1611,7 +1616,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -1632,15 +1637,15 @@
       "integrity": "sha512-gLFZz5UYvOhYzQ+DBzw/OCkmWaLAHlAyQiE2wxUOmAGVdasP9Yw93E+OwZ0UuhW3ReMu1FKniuNsL6VukvC77w==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "1.0.2",
-        "@sinonjs/formatio": "2.0.0",
-        "@sinonjs/samsam": "2.0.0",
-        "diff": "3.5.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.7.4",
-        "nise": "1.4.4",
-        "supports-color": "5.5.0",
-        "type-detect": "4.0.8"
+        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/formatio": "^2.0.0",
+        "@sinonjs/samsam": "^2.0.0",
+        "diff": "^3.5.0",
+        "lodash.get": "^4.4.2",
+        "lolex": "^2.7.2",
+        "nise": "^1.4.4",
+        "supports-color": "^5.5.0",
+        "type-detect": "^4.0.8"
       }
     },
     "slice-ansi": {
@@ -1649,7 +1654,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0"
+        "is-fullwidth-code-point": "^2.0.0"
       }
     },
     "sort-keys": {
@@ -1657,7 +1662,7 @@
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "spdx-correct": {
@@ -1666,8 +1671,8 @@
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "3.0.0",
-        "spdx-license-ids": "3.0.1"
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -1682,8 +1687,8 @@
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "2.1.0",
-        "spdx-license-ids": "3.0.1"
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-license-ids": {
@@ -1709,8 +1714,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "strip-ansi": {
@@ -1719,7 +1724,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0"
+        "ansi-regex": "^3.0.0"
       }
     },
     "strip-bom": {
@@ -1739,7 +1744,7 @@
       "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "strip-url-auth": {
@@ -1753,7 +1758,7 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "table": {
@@ -1762,12 +1767,12 @@
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.3",
-        "ajv-keywords": "3.2.0",
-        "chalk": "2.4.1",
-        "lodash": "4.17.10",
+        "ajv": "^6.0.1",
+        "ajv-keywords": "^3.0.0",
+        "chalk": "^2.1.0",
+        "lodash": "^4.17.4",
         "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
+        "string-width": "^2.1.1"
       }
     },
     "text-encoding": {
@@ -1784,7 +1789,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -1794,7 +1799,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2"
+        "os-tmpdir": "~1.0.2"
       }
     },
     "trim-repeated": {
@@ -1802,7 +1807,7 @@
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "requires": {
-        "escape-string-regexp": "1.0.5"
+        "escape-string-regexp": "^1.0.2"
       }
     },
     "tslib": {
@@ -1817,7 +1822,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -1837,7 +1842,7 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "dev": true,
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       }
     },
     "validate-npm-package-license": {
@@ -1846,8 +1851,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "3.0.0",
-        "spdx-expression-parse": "3.0.0"
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "which": {
@@ -1856,7 +1861,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "wordwrap": {
@@ -1876,7 +1881,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "commander": "^2.18.0",
+    "email-addresses": "^3.0.1",
     "filenamify-url": "^1.0.0",
     "fs-extra": "^7.0.0",
     "globby": "^6.1.0",

--- a/readme.md
+++ b/readme.md
@@ -228,26 +228,6 @@ ghpages.publish('dist', {
 ```
 
 
-#### <a id="optionsclone">options.clone</a>
- * type: `string`
- * default: temporary directory inside the `gh-pages` directory
-
-Path to a directory where your repository will be cloned.  If this directory doesn't already exist, it will be created.  If it already exists, it is assumed to be a clone of your repository.
-
-Example use of the `clone` option:
-
-```js
-/**
- * If you already have a temp directory, and want the repository cloned there,
- * use the `clone` option as below.  To avoid re-cloning every time the task is
- * run, this should be a directory that sticks around for a while.
- */
-ghpages.publish('dist', {
-  clone: 'path/to/tmp/dir'
-}, callback);
-```
-
-
 #### <a id="optionspush">options.push</a>
  * type: `boolean`
  * default: `true`

--- a/test/bin/gh-pages.spec.js
+++ b/test/bin/gh-pages.spec.js
@@ -1,4 +1,3 @@
-const helper = require('../helper');
 const ghpages = require('../../lib/index');
 const sinon = require('sinon');
 const cli = require('../../bin/gh-pages');
@@ -78,7 +77,8 @@ describe('gh-pages', () => {
       {
         args: ['--dist', 'lib', '-u', 'junk email'],
         dist: 'lib',
-        error: 'Could not parse "Full Name <email@example.com>" from junk email'
+        error:
+          'Could not parse name and email from user option "junk email" (format should be "Your Name <email@example.com>")'
       }
     ];
 
@@ -105,24 +105,6 @@ describe('gh-pages', () => {
             assert.equal(err.message, error);
             done();
           });
-      });
-    });
-  });
-
-  describe('getUser', () => {
-    it('gets the locally configured user', done => {
-      const name = 'Full Name';
-      const email = 'email@example.com';
-
-      helper.setupRepo('basic', {user: {name, email}}).then(dir => {
-        cli
-          .getUser(dir)
-          .then(user => {
-            assert.equal(user.name, name);
-            assert.equal(user.email, email);
-            done();
-          })
-          .catch(done);
       });
     });
   });

--- a/test/bin/gh-pages.spec.js
+++ b/test/bin/gh-pages.spec.js
@@ -6,13 +6,13 @@ const assert = require('../helper').assert;
 
 describe('gh-pages', () => {
   describe('main', () => {
-    beforeEach(function() {
+    beforeEach(() => {
       sinon
         .stub(ghpages, 'publish')
         .callsFake((basePath, config, callback) => callback());
     });
 
-    afterEach(function() {
+    afterEach(() => {
       ghpages.publish.restore();
     });
 

--- a/test/bin/gh-pages.spec.js
+++ b/test/bin/gh-pages.spec.js
@@ -1,46 +1,129 @@
+const helper = require('../helper');
 const ghpages = require('../../lib/index');
 const sinon = require('sinon');
 const cli = require('../../bin/gh-pages');
+const assert = require('../helper').assert;
 
-describe('gh-pages', function() {
-  beforeEach(function() {
-    sinon.stub(ghpages, 'publish');
+describe('gh-pages', () => {
+  describe('main', () => {
+    beforeEach(function() {
+      sinon
+        .stub(ghpages, 'publish')
+        .callsFake((basePath, config, callback) => callback());
+    });
+
+    afterEach(function() {
+      ghpages.publish.restore();
+    });
+
+    const defaults = {
+      repo: undefined,
+      silent: false,
+      branch: 'gh-pages',
+      src: '**/*',
+      dest: '.',
+      message: 'Updates',
+      dotfiles: false,
+      add: false,
+      remote: 'origin',
+      push: true
+    };
+
+    const scenarios = [
+      {
+        args: ['--dist', 'lib'],
+        dist: 'lib',
+        config: defaults
+      },
+      {
+        args: ['--dist', 'lib', '-n'],
+        dist: 'lib',
+        config: {push: false}
+      },
+      {
+        args: ['--dist', 'lib', '-x'],
+        dist: 'lib',
+        config: {silent: true}
+      },
+      {
+        args: ['--dist', 'lib', '--dotfiles'],
+        dist: 'lib',
+        config: {dotfiles: true}
+      },
+      {
+        args: ['--dist', 'lib', '--dest', 'target'],
+        dist: 'lib',
+        config: {dest: 'target'}
+      },
+      {
+        args: ['--dist', 'lib', '-a', 'target'],
+        dist: 'lib',
+        config: {add: true}
+      },
+      {
+        args: ['--dist', 'lib', '--user', 'Full Name <email@example.com>'],
+        dist: 'lib',
+        config: {user: {name: 'Full Name', email: 'email@example.com'}}
+      },
+      {
+        args: ['--dist', 'lib', '--user', 'email@example.com'],
+        dist: 'lib',
+        config: {user: {name: null, email: 'email@example.com'}}
+      },
+      {
+        args: ['--dist', 'lib', '-u', 'Full Name <email@example.com>'],
+        dist: 'lib',
+        config: {user: {name: 'Full Name', email: 'email@example.com'}}
+      },
+      {
+        args: ['--dist', 'lib', '-u', 'junk email'],
+        dist: 'lib',
+        error: 'Could not parse "Full Name <email@example.com>" from junk email'
+      }
+    ];
+
+    scenarios.forEach(({args, dist, config, error}) => {
+      let title = args.join(' ');
+      if (error) {
+        title += ' (user error)';
+      }
+      it(title, done => {
+        cli(['node', 'gh-pages'].concat(args))
+          .then(() => {
+            if (error) {
+              done(new Error(`Expected error "${error}" but got success`));
+              return;
+            }
+            sinon.assert.calledWithMatch(ghpages.publish, dist, config);
+            done();
+          })
+          .catch(err => {
+            if (!error) {
+              done(err);
+              return;
+            }
+            assert.equal(err.message, error);
+            done();
+          });
+      });
+    });
   });
 
-  afterEach(function() {
-    ghpages.publish.restore();
-  });
+  describe('getUser', () => {
+    it('gets the locally configured user', done => {
+      const name = 'Full Name';
+      const email = 'email@example.com';
 
-  const defaults = {
-    repo: undefined,
-    silent: false,
-    branch: 'gh-pages',
-    src: '**/*',
-    dest: '.',
-    message: 'Updates',
-    dotfiles: false,
-    add: false,
-    remote: 'origin',
-    push: true
-  };
-
-  const scenarions = [
-    ['--dist lib', 'lib', defaults],
-    ['--dist lib -n', 'lib', {push: false}],
-    ['--dist lib -x', 'lib', {silent: true}],
-    ['--dist lib --dotfiles', 'lib', {dotfiles: true}],
-    ['--dist lib --dest target', 'lib', {dest: 'target'}],
-    ['--dist lib -a', 'lib', {add: true}]
-  ];
-
-  scenarions.forEach(function(scenario) {
-    const args = scenario[0].split(' ');
-    const dist = scenario[1];
-    const config = scenario[2];
-
-    it(args.join(' '), function() {
-      cli(['node', 'gh-pages'].concat(args));
-      sinon.assert.calledWithMatch(ghpages.publish, dist, config);
+      helper.setupRepo('basic', {user: {name, email}}).then(dir => {
+        cli
+          .getUser(dir)
+          .then(user => {
+            assert.equal(user.name, name);
+            assert.equal(user.email, email);
+            done();
+          })
+          .catch(done);
+      });
     });
   });
 });

--- a/test/helper.js
+++ b/test/helper.js
@@ -23,8 +23,8 @@ exports.assert = chai.assert;
 const fixtures = path.join(__dirname, 'integration', 'fixtures');
 
 function mkdtemp() {
-  return new Promise(function(resolve, reject) {
-    tmp.dir({unsafeCleanup: true}, function(err, tmpPath) {
+  return new Promise((resolve, reject) => {
+    tmp.dir({unsafeCleanup: true}, (err, tmpPath) => {
       if (err) {
         return reject(err);
       }

--- a/test/integration/basic.spec.js
+++ b/test/integration/basic.spec.js
@@ -5,17 +5,17 @@ const path = require('path');
 const fixtures = path.join(__dirname, 'fixtures');
 const fixtureName = 'basic';
 
-beforeEach(function() {
+beforeEach(() => {
   ghPages.clean();
 });
 
-describe('basic usage', function() {
-  it('pushes the contents of a directory to a gh-pages branch', function(done) {
+describe('basic usage', () => {
+  it('pushes the contents of a directory to a gh-pages branch', done => {
     const local = path.join(fixtures, fixtureName, 'local');
     const expected = path.join(fixtures, fixtureName, 'expected');
     const branch = 'gh-pages';
 
-    helper.setupRemote(fixtureName, {branch}).then(function(url) {
+    helper.setupRemote(fixtureName, {branch}).then(url => {
       const options = {
         repo: url,
         user: {
@@ -23,25 +23,23 @@ describe('basic usage', function() {
           email: 'user@email.com'
         }
       };
-      ghPages.publish(local, options, function(err) {
+      ghPages.publish(local, options, err => {
         if (err) {
           return done(err);
         }
         helper
           .assertContentsMatch(expected, url, branch)
-          .then(function() {
-            done();
-          })
+          .then(() => done())
           .catch(done);
       });
     });
   });
 
-  it('can push to a different branch', function(done) {
+  it('can push to a different branch', done => {
     const local = path.join(fixtures, fixtureName, 'local');
     const branch = 'master';
 
-    helper.setupRemote(fixtureName, {branch}).then(function(url) {
+    helper.setupRemote(fixtureName, {branch}).then(url => {
       const options = {
         repo: url,
         branch: branch,
@@ -50,15 +48,13 @@ describe('basic usage', function() {
           email: 'user@email.com'
         }
       };
-      ghPages.publish(local, options, function(err) {
+      ghPages.publish(local, options, err => {
         if (err) {
           return done(err);
         }
         helper
           .assertContentsMatch(local, url, branch)
-          .then(function() {
-            done();
-          })
+          .then(() => done())
           .catch(done);
       });
     });

--- a/test/integration/basic.spec.js
+++ b/test/integration/basic.spec.js
@@ -15,7 +15,7 @@ describe('basic usage', function() {
     const expected = path.join(fixtures, fixtureName, 'expected');
     const branch = 'gh-pages';
 
-    helper.setupRemote(fixtureName, branch).then(function(url) {
+    helper.setupRemote(fixtureName, {branch}).then(function(url) {
       const options = {
         repo: url,
         user: {
@@ -41,7 +41,7 @@ describe('basic usage', function() {
     const local = path.join(fixtures, fixtureName, 'local');
     const branch = 'master';
 
-    helper.setupRemote(fixtureName, branch).then(function(url) {
+    helper.setupRemote(fixtureName, {branch}).then(function(url) {
       const options = {
         repo: url,
         branch: branch,

--- a/test/integration/dest.spec.js
+++ b/test/integration/dest.spec.js
@@ -5,18 +5,18 @@ const path = require('path');
 const fixtures = path.join(__dirname, 'fixtures');
 const fixtureName = 'dest';
 
-beforeEach(function() {
+beforeEach(() => {
   ghPages.clean();
 });
 
-describe('the dest option', function() {
-  it('allows publishing to a subdirectory within a branch', function(done) {
+describe('the dest option', () => {
+  it('allows publishing to a subdirectory within a branch', done => {
     const local = path.join(fixtures, fixtureName, 'local');
     const expected = path.join(fixtures, fixtureName, 'expected');
     const branch = 'gh-pages';
     const dest = 'target';
 
-    helper.setupRemote(fixtureName, {branch}).then(function(url) {
+    helper.setupRemote(fixtureName, {branch}).then(url => {
       const options = {
         repo: url,
         dest: dest,

--- a/test/integration/dest.spec.js
+++ b/test/integration/dest.spec.js
@@ -16,7 +16,7 @@ describe('the dest option', function() {
     const branch = 'gh-pages';
     const dest = 'target';
 
-    helper.setupRemote(fixtureName, branch).then(function(url) {
+    helper.setupRemote(fixtureName, {branch}).then(function(url) {
       const options = {
         repo: url,
         dest: dest,
@@ -26,15 +26,13 @@ describe('the dest option', function() {
         }
       };
 
-      ghPages.publish(local, options, function(err) {
+      ghPages.publish(local, options, err => {
         if (err) {
           return done(err);
         }
         helper
           .assertContentsMatch(expected, url, branch)
-          .then(function() {
-            done();
-          })
+          .then(() => done())
           .catch(done);
       });
     });

--- a/test/integration/include.spec.js
+++ b/test/integration/include.spec.js
@@ -5,12 +5,12 @@ const path = require('path');
 const fixtures = path.join(__dirname, 'fixtures');
 const fixtureName = 'include';
 
-beforeEach(function() {
+beforeEach(() => {
   ghPages.clean();
 });
 
-describe('the src option', function() {
-  it('can be used to limit which files are included', function(done) {
+describe('the src option', () => {
+  it('can be used to limit which files are included', done => {
     const local = path.join(fixtures, fixtureName, 'local');
     const expected = path.join(fixtures, fixtureName, 'expected');
     const branch = 'gh-pages';

--- a/test/integration/include.spec.js
+++ b/test/integration/include.spec.js
@@ -15,7 +15,7 @@ describe('the src option', function() {
     const expected = path.join(fixtures, fixtureName, 'expected');
     const branch = 'gh-pages';
 
-    helper.setupRemote(fixtureName, branch).then(function(url) {
+    helper.setupRemote(fixtureName, {branch}).then(url => {
       const options = {
         repo: url,
         src: '**/*.js',
@@ -25,15 +25,13 @@ describe('the src option', function() {
         }
       };
 
-      ghPages.publish(local, options, function(err) {
+      ghPages.publish(local, options, err => {
         if (err) {
           return done(err);
         }
         helper
           .assertContentsMatch(expected, url, branch)
-          .then(function() {
-            done();
-          })
+          .then(() => done())
           .catch(done);
       });
     });

--- a/test/lib/util.spec.js
+++ b/test/lib/util.spec.js
@@ -4,9 +4,9 @@ const assert = require('../helper').assert;
 
 const util = require('../../lib/util');
 
-describe('util', function() {
+describe('util', () => {
   let files;
-  beforeEach(function() {
+  beforeEach(() => {
     files = [
       path.join('a1', 'b1', 'c2', 'd2.txt'),
       path.join('a1', 'b2', 'c2', 'd1.txt'),
@@ -23,8 +23,8 @@ describe('util', function() {
     ].slice();
   });
 
-  describe('byShortPath', function() {
-    it('sorts an array of filepaths, shortest first', function() {
+  describe('byShortPath', () => {
+    it('sorts an array of filepaths, shortest first', () => {
       files.sort(util.byShortPath);
 
       const expected = [
@@ -46,8 +46,8 @@ describe('util', function() {
     });
   });
 
-  describe('uniqueDirs', function() {
-    it('gets a list of unique directory paths', function() {
+  describe('uniqueDirs', () => {
+    it('gets a list of unique directory paths', () => {
       // not comparing order here, so we sort both
       const got = util.uniqueDirs(files).sort();
 
@@ -67,8 +67,8 @@ describe('util', function() {
       assert.deepEqual(got, expected);
     });
 
-    it('gets a list of unique directories on absolute paths', function() {
-      const absoluteFiles = files.map(function(path) {
+    it('gets a list of unique directories on absolute paths', () => {
+      const absoluteFiles = files.map(path => {
         return '/' + path;
       });
       // not comparing order here, so we sort both
@@ -91,8 +91,8 @@ describe('util', function() {
     });
   });
 
-  describe('dirsToCreate', function() {
-    it('gets a sorted list of directories to create', function() {
+  describe('dirsToCreate', () => {
+    it('gets a sorted list of directories to create', () => {
       const got = util.dirsToCreate(files);
 
       const expected = [

--- a/test/lib/util.spec.js
+++ b/test/lib/util.spec.js
@@ -1,8 +1,7 @@
 const path = require('path');
-
 const assert = require('../helper').assert;
-
 const util = require('../../lib/util');
+const helper = require('../helper');
 
 describe('util', () => {
   let files;
@@ -109,6 +108,24 @@ describe('util', () => {
       ];
 
       assert.deepEqual(got, expected);
+    });
+  });
+
+  describe('getUser', () => {
+    it('gets the locally configured user', done => {
+      const name = 'Full Name';
+      const email = 'email@example.com';
+
+      helper.setupRepo('basic', {user: {name, email}}).then(dir => {
+        util
+          .getUser(dir)
+          .then(user => {
+            assert.equal(user.name, name);
+            assert.equal(user.email, email);
+            done();
+          })
+          .catch(done);
+      });
     });
   });
 });


### PR DESCRIPTION
When the `gh-pages` command runs, it creates a repo in a cache directory.  By default, this directory is in the `gh-pages` install directory (e.g. `path/to/node_modules/gh-pages/.cache`).

Previously, commits that were created in the cached repo used the `git config user.email` and `git config user.name` as determined from the cached repo.  In the case of a global `gh-pages` install, this user name and email would most likely be the global git user.  In the case of a local `gh-pages` install, this would be a local git user if one was configured.

This branch changes things so that the user is determined by running `git config user.email` (and same for name) in the current working directory.  This means that the git user will be the local user if the current directory is a git repo and has a locally configured user.  Otherwise it will be the global git user.

To override the behavior of determining the git user, a `user` option can be provided.  For the CLI, the format of this option is "Full Name <email@example.com" (see [RFC-5322](https://tools.ietf.org/html/rfc5322#section-3.4)).  For example:

```
gh-pages -d dist --user "Your Name <you@example.com>"
```

The same behavior applies to programmatic usage.  A `{name, email}` object can be provided for the `user` option.  If not provided, `git config user.email` will be run in the current working directory.

Thanks to @holloway for initiating this in #229.  And to @nuklearfiziks for resurrecting it once and @paulirish for resurrecting it a second time in #261.
