### PR TITLE
cli: add `--no-history` flag not to preserve deploy history

### DIFF
--- a/bin/gh-pages.js
+++ b/bin/gh-pages.js
@@ -66,6 +66,10 @@ function main(args) {
         ghpages.defaults.only
       )
       .option('-n, --no-push', 'Commit only (with no push)')
+      .option(
+        '-f, --no-history',
+        'Push force new commit without parent history'
+      )
       .parse(args);
 
     let user;
@@ -95,6 +99,7 @@ function main(args) {
       only: program.remove,
       remote: program.remote,
       push: !!program.push,
+      history: !!program.history,
       user: user
     };
 

--- a/lib/git.js
+++ b/lib/git.js
@@ -176,10 +176,15 @@ Git.prototype.tag = function(name) {
  * Push a branch.
  * @param {string} remote Remote alias.
  * @param {string} branch Branch name.
+ * @param {boolean} force Force push.
  * @return {Promise} A promise.
  */
-Git.prototype.push = function(remote, branch) {
-  return this.exec('push', '--tags', remote, branch);
+Git.prototype.push = function(remote, branch, force) {
+  const args = ['push', '--tags', remote, branch];
+  if (force) {
+    args.push('--force');
+  }
+  return this.exec.apply(this, args);
 };
 
 /**
@@ -210,6 +215,14 @@ Git.prototype.getRemoteUrl = function(remote) {
           'or must be configured with the "repo" option).'
       );
     });
+};
+
+/**
+ * Delete ref to remove branch history
+ * @param {string} branch
+ */
+Git.prototype.deleteRef = function(branch) {
+  return this.exec('update-ref', '-d', 'refs/heads/' + branch);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,7 @@ exports.defaults = {
   src: '**/*',
   only: '.',
   push: true,
+  history: true,
   message: 'Updates',
   silent: false
 };
@@ -143,6 +144,13 @@ exports.publish = function publish(basePath, config, callback) {
         return git.checkout(options.remote, options.branch);
       })
       .then(git => {
+        if (!options.history) {
+          return git.deleteRef(options.branch);
+        } else {
+          return git;
+        }
+      })
+      .then(git => {
         if (!options.add) {
           log('Removing files');
           return git.rm(only.join(' '));
@@ -193,7 +201,7 @@ exports.publish = function publish(basePath, config, callback) {
       .then(git => {
         if (options.push) {
           log('Pushing');
-          return git.push(options.remote, options.branch);
+          return git.push(options.remote, options.branch, !options.history);
         } else {
           return git;
         }

--- a/readme.md
+++ b/readme.md
@@ -241,6 +241,19 @@ ghpages.publish('dist', {push: false}, callback);
 ```
 
 
+#### <a id="optionshistory">options.history</a>
+ * type: `boolean`
+ * default: `true`
+
+Push force new commit without parent history.
+
+Example use of the `history` option:
+
+```js
+ghpages.publish('dist', {history: false}, callback);
+```
+
+
 #### <a id="optionssilent">options.silent</a>
  * type: `boolean`
  * default: `false`

--- a/test/bin/gh-pages.spec.js
+++ b/test/bin/gh-pages.spec.js
@@ -27,6 +27,11 @@ describe('gh-pages', () => {
         config: {push: false}
       },
       {
+        args: ['--dist', 'lib', '-f'],
+        dist: 'lib',
+        config: {history: false}
+      },
+      {
         args: ['--dist', 'lib', '-x'],
         dist: 'lib',
         config: {silent: true}


### PR DESCRIPTION
Implemented with reference to `keep-history` of [Travis GitHub Pages Deployment](https://docs.travis-ci.com/user/deployment/pages/).