### PR TITLE
fix: make the default config work properly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,8 +48,11 @@ exports.publish = function publish(basePath, config, callback) {
     message: 'Updates',
     silent: false
   };
+
   // Remove undefined properties from config:
-  Object.keys(config).forEach(key => config[key] === undefined && delete config[key])
+  Object.keys(config).forEach(
+    key => config[key] === undefined && delete config[key]
+  );
 
   const options = Object.assign({}, defaults, config);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,6 +48,8 @@ exports.publish = function publish(basePath, config, callback) {
     message: 'Updates',
     silent: false
   };
+  // Remove undefined properties from config:
+  Object.keys(config).forEach(key => config[key] === undefined && delete config[key])
 
   const options = Object.assign({}, defaults, config);
 


### PR DESCRIPTION
This is a fix for https://github.com/tschaub/gh-pages/issues/308

After
https://github.com/tschaub/gh-pages/commit/2fb83f5afc25528fe42683978a3191485a95e77e#diff-6eec2f2dfcb5bb90afa10af53927034bR83
the "git"-property will always exist on the config-object, even if the value of it is undefined.

In that case, the `Object.assign()` in _lib/index.js:52_ will not pick the default property, but instead the (undefined) property of the config-object.

This PR fixes the issue by removing all _undefined_ properties from the config object, allowing the default-properties to properly take over.