### PR TITLE
Add default value for git option

### DIFF
--- a/bin/gh-pages.js
+++ b/bin/gh-pages.js
@@ -26,27 +26,35 @@ function main(args) {
       .option(
         '-s, --src <src>',
         'Pattern used to select which files to publish',
-        '**/*'
+        ghpages.defaults.src
       )
       .option(
         '-b, --branch <branch>',
         'Name of the branch you are pushing to',
-        'gh-pages'
+        ghpages.defaults.branch
       )
       .option(
         '-e, --dest <dest>',
         'Target directory within the destination branch (relative to the root)',
-        '.'
+        ghpages.defaults.dest
       )
       .option('-a, --add', 'Only add, and never remove existing files')
       .option('-x, --silent', 'Do not output the repository url')
-      .option('-m, --message <message>', 'commit message', 'Updates')
+      .option(
+        '-m, --message <message>',
+        'commit message',
+        ghpages.defaults.message
+      )
       .option('-g, --tag <tag>', 'add tag to commit')
-      .option('--git <git>', 'Path to git executable')
+      .option('--git <git>', 'Path to git executable', ghpages.defaults.git)
       .option('-t, --dotfiles', 'Include dotfiles')
       .option('-r, --repo <repo>', 'URL of the repository you are pushing to')
-      .option('-p, --depth <depth>', 'depth for clone', 1)
-      .option('-o, --remote <name>', 'The name of the remote', 'origin')
+      .option('-p, --depth <depth>', 'depth for clone', ghpages.defaults.depth)
+      .option(
+        '-o, --remote <name>',
+        'The name of the remote',
+        ghpages.defaults.remote
+      )
       .option(
         '-u, --user <address>',
         'The name and email of the user (defaults to the git config).  Format is "Your Name <email@example.com>".'
@@ -55,7 +63,7 @@ function main(args) {
         '-v, --remove <pattern>',
         'Remove files that match the given pattern ' +
           '(ignored if used together with --add).',
-        '.'
+        ghpages.defaults.only
       )
       .option('-n, --no-push', 'Commit only (with no push)')
       .parse(args);
@@ -81,6 +89,7 @@ function main(args) {
       message: program.message,
       tag: program.tag,
       git: program.git,
+      depth: program.depth,
       dotfiles: !!program.dotfiles,
       add: !!program.add,
       only: program.remove,

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,21 @@ function getRepo(options) {
   }
 }
 
+exports.defaults = {
+  dest: '.',
+  add: false,
+  git: 'git',
+  depth: 1,
+  dotfiles: false,
+  branch: 'gh-pages',
+  remote: 'origin',
+  src: '**/*',
+  only: '.',
+  push: true,
+  message: 'Updates',
+  silent: false
+};
+
 /**
  * Push a git branch to a remote (pushes gh-pages by default).
  * @param {string} basePath The base path.
@@ -34,22 +49,7 @@ exports.publish = function publish(basePath, config, callback) {
     config = {};
   }
 
-  const defaults = {
-    dest: '.',
-    add: false,
-    git: 'git',
-    depth: 1,
-    dotfiles: false,
-    branch: 'gh-pages',
-    remote: 'origin',
-    src: '**/*',
-    only: '.',
-    push: true,
-    message: 'Updates',
-    silent: false
-  };
-
-  const options = Object.assign({}, defaults, config);
+  const options = Object.assign({}, exports.defaults, config);
 
   if (!callback) {
     callback = function(err) {

--- a/test/bin/gh-pages.spec.js
+++ b/test/bin/gh-pages.spec.js
@@ -15,24 +15,11 @@ describe('gh-pages', () => {
       ghpages.publish.restore();
     });
 
-    const defaults = {
-      repo: undefined,
-      silent: false,
-      branch: 'gh-pages',
-      src: '**/*',
-      dest: '.',
-      message: 'Updates',
-      dotfiles: false,
-      add: false,
-      remote: 'origin',
-      push: true
-    };
-
     const scenarios = [
       {
         args: ['--dist', 'lib'],
         dist: 'lib',
-        config: defaults
+        config: ghpages.defaults
       },
       {
         args: ['--dist', 'lib', '-n'],


### PR DESCRIPTION
Support for a `--git` option was added in #303 and released in 2.1.0.  Because a default value was not provided, this broke all use without the `--git` option.  This fixes that.

Thanks @webkadiz for the proposed fix in #311 and @nytamin for #309.

Fixes #308.