### PR TITLE
Allow an absolute path as dist directory

### DIFF
--- a/bin/gh-pages.js
+++ b/bin/gh-pages.js
@@ -8,7 +8,10 @@ const addr = require('email-addresses');
 
 function publish(config) {
   return new Promise((resolve, reject) => {
-    const basePath = path.join(process.cwd(), program.dist);
+    let basePath = program.dist;
+    if (!program.dist.startsWith('/')) {
+      basePath = path.join(process.cwd(), program.dist);
+    }
     ghpages.publish(basePath, config, err => {
       if (err) {
         return reject(err);

--- a/bin/gh-pages.js
+++ b/bin/gh-pages.js
@@ -8,10 +8,7 @@ const addr = require('email-addresses');
 
 function publish(config) {
   return new Promise((resolve, reject) => {
-    let basePath = program.dist;
-    if (!program.dist.startsWith('/')) {
-      basePath = path.join(process.cwd(), program.dist);
-    }
+    const basePath = path.resolve(process.cwd(), program.dist);
     ghpages.publish(basePath, config, err => {
       if (err) {
         return reject(err);


### PR DESCRIPTION
It allows using an absolute path to start with `/` as the dist directory. The use case is it can be used the dist directory as a path not be under the current directory.

It might be a breaking change because of behavior changes on a pass a path to start with `/`. Please bump a major version if needed.

Fixes: #317
