### PR TITLE
Fix remove not working properly

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "bracketSpacing": false,
-  "tabWidth": 2,
-  "singleQuote": true
-}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "bracketSpacing": false,
+  "tabWidth": 2,
+  "singleQuote": true
+}

--- a/bin/gh-pages.js
+++ b/bin/gh-pages.js
@@ -81,7 +81,7 @@ function main(args) {
             '(format should be "Your Name <email@example.com>")'
         );
       }
-      user = { name: parts.name, email: parts.address };
+      user = {name: parts.name, email: parts.address};
     }
 
     const config = {

--- a/bin/gh-pages.js
+++ b/bin/gh-pages.js
@@ -63,7 +63,7 @@ function main(args) {
         '-v, --remove <pattern>',
         'Remove files that match the given pattern ' +
           '(ignored if used together with --add).',
-        ghpages.defaults.only
+        ghpages.defaults.remove
       )
       .option('-n, --no-push', 'Commit only (with no push)')
       .option(
@@ -81,7 +81,7 @@ function main(args) {
             '(format should be "Your Name <email@example.com>")'
         );
       }
-      user = {name: parts.name, email: parts.address};
+      user = { name: parts.name, email: parts.address };
     }
 
     const config = {
@@ -96,7 +96,7 @@ function main(args) {
       depth: program.depth,
       dotfiles: !!program.dotfiles,
       add: !!program.add,
-      only: program.remove,
+      remove: program.remove,
       remote: program.remote,
       push: !!program.push,
       history: !!program.history,

--- a/lib/git.js
+++ b/lib/git.js
@@ -66,7 +66,7 @@ function Git(cwd, cmd) {
  *     or rejected with an error.
  */
 Git.prototype.exec = function() {
-  return spawn(this.cmd, [].slice.call(arguments), this.cwd).then(output => {
+  return spawn(this.cmd, [...arguments], this.cwd).then(output => {
     this.output = output;
     return this;
   });
@@ -136,20 +136,26 @@ Git.prototype.checkout = function(remote, branch) {
 
 /**
  * Remove all unversioned files.
- * @param {string} files Files argument.
+ * @param {string|string[]} files Files argument.
  * @return {Promise} A promise.
  */
 Git.prototype.rm = function(files) {
-  return this.exec('rm', '--ignore-unmatch', '-r', '-f', files);
+  if (!Array.isArray(files)) {
+    files = [files];
+  }
+  return this.exec('rm', '--ignore-unmatch', '-r', '-f', ...files);
 };
 
 /**
  * Add files.
- * @param {string} files Files argument.
+ * @param {string|string[]} files Files argument.
  * @return {Promise} A promise.
  */
 Git.prototype.add = function(files) {
-  return this.exec('add', files);
+  if (!Array.isArray(files)) {
+    files = [files];
+  }
+  return this.exec('add', ...files);
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -147,18 +147,16 @@ exports.publish = function publish(basePath, config, callback) {
         }
       })
       .then(git => {
-        if (!options.add) {
-          log('Removing files');
-          const only = globby
-            .sync(options.only, { cwd: basePath })
-            .map(file => {
-              return path.join(options.dest, file);
-            });
-          if (only.length > 0) {
-            return git.rm(only.join(' '));
-          } else {
-            return git;
-          }
+        if (options.add) {
+          return git;
+        }
+
+        log('Removing files');
+        const only = globby.sync(options.only, { cwd: basePath }).map(file => {
+          return path.join(options.dest, file);
+        });
+        if (only.length > 0) {
+          return git.rm(only.join(' '));
         } else {
           return git;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -163,7 +163,7 @@ exports.publish = function publish(basePath, config, callback) {
           })
           .map(file => path.join(options.dest, file));
         if (files.length > 0) {
-          return git.rm(files.join(' '));
+          return git.rm(files);
         } else {
           return git;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,7 +31,7 @@ exports.defaults = {
   branch: 'gh-pages',
   remote: 'origin',
   src: '**/*',
-  only: '.',
+  remove: '.',
   push: true,
   history: true,
   message: 'Updates',
@@ -51,6 +51,11 @@ exports.publish = function publish(basePath, config, callback) {
   }
 
   const options = Object.assign({}, exports.defaults, config);
+
+  // For backward compatibility before fixing #334
+  if (options.only) {
+    options.remove = options.only;
+  }
 
   if (!callback) {
     callback = function(err) {
@@ -152,7 +157,7 @@ exports.publish = function publish(basePath, config, callback) {
         }
 
         log('Removing files');
-        const files = globby.sync(options.only, {
+        const files = globby.sync(options.remove, {
           cwd: path.join(git.cwd, options.dest)
         });
         if (files.length > 0) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -152,11 +152,11 @@ exports.publish = function publish(basePath, config, callback) {
         }
 
         log('Removing files');
-        const only = globby.sync(options.only, { cwd: basePath }).map(file => {
-          return path.join(options.dest, file);
+        const files = globby.sync(options.only, {
+          cwd: path.join(git.cwd, options.dest)
         });
-        if (only.length > 0) {
-          return git.rm(only.join(' '));
+        if (files.length > 0) {
+          return git.rm(files.join(' '));
         } else {
           return git;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -94,10 +94,6 @@ exports.publish = function publish(basePath, config, callback) {
     return;
   }
 
-  const only = globby.sync(options.only, {cwd: basePath}).map(file => {
-    return path.join(options.dest, file);
-  });
-
   let repoUrl;
   let userPromise;
   if (options.user) {
@@ -151,9 +147,18 @@ exports.publish = function publish(basePath, config, callback) {
         }
       })
       .then(git => {
-        if (!options.add && only.length > 0) {
+        if (!options.add) {
           log('Removing files');
-          return git.rm(only.join(' '));
+          const only = globby
+            .sync(options.only, { cwd: basePath })
+            .map(file => {
+              return path.join(options.dest, file);
+            });
+          if (only.length > 0) {
+            return git.rm(only.join(' '));
+          } else {
+            return git;
+          }
         } else {
           return git;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -157,9 +157,11 @@ exports.publish = function publish(basePath, config, callback) {
         }
 
         log('Removing files');
-        const files = globby.sync(options.remove, {
-          cwd: path.join(git.cwd, options.dest)
-        });
+        const files = globby
+          .sync(options.remove, {
+            cwd: path.join(git.cwd, options.dest)
+          })
+          .map(file => path.join(options.dest, file));
         if (files.length > 0) {
           return git.rm(files.join(' '));
         } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -151,7 +151,7 @@ exports.publish = function publish(basePath, config, callback) {
         }
       })
       .then(git => {
-        if (!options.add) {
+        if (!options.add && only.length > 0) {
           log('Removing files');
           return git.rm(only.join(' '));
         } else {

--- a/test/integration/fixtures/remove/expected/new.js
+++ b/test/integration/fixtures/remove/expected/new.js
@@ -1,0 +1,1 @@
+// to be copied

--- a/test/integration/fixtures/remove/expected/stable.txt
+++ b/test/integration/fixtures/remove/expected/stable.txt
@@ -1,0 +1,1 @@
+This file should not be removed.

--- a/test/integration/fixtures/remove/local/new.js
+++ b/test/integration/fixtures/remove/local/new.js
@@ -1,0 +1,1 @@
+// to be copied

--- a/test/integration/fixtures/remove/remote/removed.css
+++ b/test/integration/fixtures/remove/remote/removed.css
@@ -1,0 +1,1 @@
+/* to be removed */

--- a/test/integration/fixtures/remove/remote/removed.js
+++ b/test/integration/fixtures/remove/remote/removed.js
@@ -1,0 +1,1 @@
+// to be removed

--- a/test/integration/fixtures/remove/remote/stable.txt
+++ b/test/integration/fixtures/remove/remote/stable.txt
@@ -1,0 +1,1 @@
+This file should not be removed.

--- a/test/integration/remove.spec.js
+++ b/test/integration/remove.spec.js
@@ -1,0 +1,67 @@
+const helper = require('../helper');
+const ghPages = require('../../lib/');
+const path = require('path');
+
+const fixtures = path.join(__dirname, 'fixtures');
+const fixtureName = 'remove';
+
+beforeEach(() => {
+  ghPages.clean();
+});
+
+describe('the remove option', () => {
+  it('removes matched files in remote branch', done => {
+    const local = path.join(fixtures, fixtureName, 'local');
+    const expected = path.join(fixtures, fixtureName, 'expected');
+    const branch = 'gh-pages';
+    const remove = '*.{js,css}';
+
+    helper.setupRemote(fixtureName, {branch}).then(url => {
+      const options = {
+        repo: url,
+        user: {
+          name: 'User Name',
+          email: 'user@email.com'
+        },
+        remove: remove
+      };
+
+      ghPages.publish(local, options, err => {
+        if (err) {
+          return done(err);
+        }
+        helper
+          .assertContentsMatch(expected, url, branch)
+          .then(() => done())
+          .catch(done);
+      });
+    });
+  });
+
+  it('skips removing files if there are no files to be removed', done => {
+    const local = path.join(fixtures, fixtureName, 'remote');
+    const branch = 'gh-pages';
+    const remove = 'non-exist-file';
+
+    helper.setupRemote(fixtureName, {branch}).then(url => {
+      const options = {
+        repo: url,
+        user: {
+          name: 'User Name',
+          email: 'user@email.com'
+        },
+        remove: remove
+      };
+
+      ghPages.publish(local, options, err => {
+        if (err) {
+          return done(err);
+        }
+        helper
+          .assertContentsMatch(local, url, branch)
+          .then(() => done())
+          .catch(done);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes some issues described below and resolves #334, fixes #337 .

## Remove globbed files

https://github.com/tschaub/gh-pages/blob/3579ab235d5502a2a1dc4d2f18ec1c9dce03f94a/lib/index.js#L156

Joining files in a string causes incorrect shell argument passing. A globbed file can be removed, but globbed files cannot be removed since the actual command will be

```
git rm -r -f "abc.js abc.css"
```

This PR makes `git.rm` and `git.add` accept `string[]` and handle them properly.

## Remove files in remote dist directory, not in local one

https://github.com/tschaub/gh-pages/blob/3579ab235d5502a2a1dc4d2f18ec1c9dce03f94a/lib/index.js#L97-L99

This shows that **gh-pages** globs files to be removed in local dist directory, not in remote branch. It causes git a fatal error(like #337) since it tries to remove files that are not in remote dist directory. `globby.sync` should be executed in remote dist directory.

## Skip removing files if there are no globbed files

When [`globby.sync`](https://github.com/tschaub/gh-pages/blob/3579ab235d5502a2a1dc4d2f18ec1c9dce03f94a/lib/index.js#L97-L99) globs files, it returns empty array if there are no files to be removed. A guard of it should be added before 

https://github.com/tschaub/gh-pages/blob/3579ab235d5502a2a1dc4d2f18ec1c9dce03f94a/lib/index.js#L156
