### PR TITLE
Add GitHub Actions tips to readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -387,3 +387,43 @@ Note that this plugin requires Git 1.9 or higher (because it uses the `--exit-co
 The `gh-pages` module writes temporary files to a `node_modules/.cache/gh-pages` directory.  The location of this directory can be customized by setting the `CACHE_DIR` environemnt variable.
 
 If `gh-pages` fails, you may find that you need to manually clean up the cache directory.  To remove the cache directory, run `node_modules/gh-pages/bin/gh-pages-clean` or remove `node_modules/.cache/gh-pages`.
+
+### Deploying with GitHub Actions
+
+In order to deploy with GitHub Actions, you will need to define a user and set the git repository for the process. See the example step below
+
+```yaml
+- name: Deploy with gh-pages
+  run: |
+    git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+    npx gh-pages -d build -u "github-actions-bot <support+actions@github.com>"
+   env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The `secrets.GITHUB_TOKEN` is provided automatically as part of the GitHub Action and does not require any further configuration, but simply needs to be passed in as an environmental variable to the step. `GITHUB_REPOSITORY` is the owner and repository name and is also passed in automatically, but does not need to be added to the `env` list.
+
+See [Issue #345](https://github.com/tschaub/gh-pages/issues/345) for more information
+
+#### Deploying with GitHub Actions and a named script
+
+If you are using a named script in the `package.json` file to deploy, you will need to ensure you pass the variables properly to the wrapped `gh-pages` script. Given the `package.json` script below:
+
+```json
+"scripts": {
+  "deploy": "gh-pages -d build"
+}
+```
+
+You will need to utilize the `--` option to pass any additional arguments:
+
+```yaml
+- name: Deploy with gh-pages
+  run: |
+    git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+    npm run deploy -- -u "github-actions-bot <support+actions@github.com>"
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+See [Pull Request #368](https://github.com/tschaub/gh-pages/pull/368) for more information.


### PR DESCRIPTION
Please see #368 for the full breakdown of this addition. Due to issues with a fork, that PR needed to be recreated to be properly updated.

The updates to the original PR include minor adjustments to the URL when defining the step and some minor formatting improvements, as well as the addition of a section describing how to use named scripts inside the Action(s).