### PR TITLE
Switch from filenamify-url to filenamify

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 const findCacheDir = require('find-cache-dir');
 const Git = require('./git');
-const filenamify = require('filenamify-url');
+const filenamify = require('filenamify');
 const copy = require('./util').copy;
 const getUser = require('./util').getUser;
 const fs = require('fs-extra');

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,9 +10,20 @@ const util = require('util');
 
 const log = util.debuglog('gh-pages');
 
-function getCacheDir() {
-  return findCacheDir({name: 'gh-pages'});
+/**
+ * Get the cache directory.
+ * @param {string} [optPath] Optional path.
+ * @returns {string} The full path to the cache directory.
+ */
+function getCacheDir(optPath) {
+  const dir = findCacheDir({name: 'gh-pages'});
+  if (!optPath) {
+    return dir;
+  }
+
+  return path.join(dir, filenamify(optPath));
 }
+exports.getCacheDir = getCacheDir;
 
 function getRepo(options) {
   if (options.repo) {
@@ -111,7 +122,7 @@ exports.publish = function publish(basePath, config, callback) {
     getRepo(options)
       .then(repo => {
         repoUrl = repo;
-        const clone = path.join(getCacheDir(), filenamify(repo));
+        const clone = getCacheDir(repo);
         log('Cloning %s into %s', repo, clone);
         return Git.clone(repo, clone, options.branch, options);
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "async": "^2.6.1",
         "commander": "^2.18.0",
         "email-addresses": "^3.0.1",
-        "filenamify-url": "^1.0.0",
+        "filenamify": "^4.3.0",
         "find-cache-dir": "^3.3.1",
         "fs-extra": "^8.1.0",
         "globby": "^6.1.0"
@@ -1182,36 +1182,27 @@
       }
     },
     "node_modules/filename-reserved-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik=",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=4"
       }
     },
     "node_modules/filenamify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
-      "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
       "dependencies": {
-        "filename-reserved-regex": "^1.0.0",
-        "strip-outer": "^1.0.0",
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
         "trim-repeated": "^1.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/filenamify-url": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
-      "integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
-      "dependencies": {
-        "filenamify": "^1.0.0",
-        "humanize-url": "^1.0.0"
+        "node": ">=8"
       },
-      "engines": {
-        "node": ">=0.10.0"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/fill-range": {
@@ -1545,18 +1536,6 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
-    "node_modules/humanize-url": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
-      "integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
-      "dependencies": {
-        "normalize-url": "^1.0.0",
-        "strip-url-auth": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -1675,14 +1654,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-regex": {
@@ -2148,20 +2119,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/normalize-url": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-      "dependencies": {
-        "object-assign": "^4.0.1",
-        "prepend-http": "^1.0.0",
-        "query-string": "^4.1.0",
-        "sort-keys": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2425,14 +2382,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
@@ -2473,18 +2422,6 @@
       "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "dependencies": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/randombytes": {
@@ -2722,17 +2659,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/sort-keys": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "dependencies": {
-        "is-plain-obj": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -2770,14 +2696,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "node_modules/strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/string-width": {
       "version": "4.2.2",
@@ -2862,14 +2780,6 @@
       "dependencies": {
         "escape-string-regexp": "^1.0.2"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/strip-url-auth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
-      "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4146,27 +4056,18 @@
       }
     },
     "filename-reserved-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
-      "integrity": "sha1-5hz4BfDeHJhFZ9A4bcXfUO5a9+Q="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha1-q/c9+rc10EVECr/qLZHzieu/oik="
     },
     "filenamify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.2.1.tgz",
-      "integrity": "sha1-qfL/0RxQO+0wABUCknI3jx8TZaU=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
       "requires": {
-        "filename-reserved-regex": "^1.0.0",
-        "strip-outer": "^1.0.0",
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
         "trim-repeated": "^1.0.0"
-      }
-    },
-    "filenamify-url": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/filenamify-url/-/filenamify-url-1.0.0.tgz",
-      "integrity": "sha1-syvYExnvWGO3MHi+1Q9GpPeXX1A=",
-      "requires": {
-        "filenamify": "^1.0.0",
-        "humanize-url": "^1.0.0"
       }
     },
     "fill-range": {
@@ -4417,15 +4318,6 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
-    "humanize-url": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
-      "integrity": "sha1-9KuZ4NKIF0yk4eUEB8VfuuRk7/8=",
-      "requires": {
-        "normalize-url": "^1.0.0",
-        "strip-url-auth": "^1.0.0"
-      }
-    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -4515,11 +4407,6 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-regex": {
       "version": "1.1.0",
@@ -4889,17 +4776,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
-    "normalize-url": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-      "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-      "requires": {
-        "object-assign": "^4.0.1",
-        "prepend-http": "^1.0.0",
-        "query-string": "^4.1.0",
-        "sort-keys": "^1.0.0"
-      }
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5099,11 +4975,6 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-    },
     "prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
@@ -5130,15 +5001,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "query-string": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-      "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-      "requires": {
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
-      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -5307,14 +5169,6 @@
         }
       }
     },
-    "sort-keys": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "requires": {
-        "is-plain-obj": "^1.0.0"
-      }
-    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -5352,11 +5206,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
-    },
-    "strict-uri-encode": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-width": {
       "version": "4.2.2",
@@ -5425,11 +5274,6 @@
       "requires": {
         "escape-string-regexp": "^1.0.2"
       }
-    },
-    "strip-url-auth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-url-auth/-/strip-url-auth-1.0.1.tgz",
-      "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164="
     },
     "supports-color": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "async": "^2.6.1",
     "commander": "^2.18.0",
     "email-addresses": "^3.0.1",
-    "filenamify-url": "^1.0.0",
+    "filenamify": "^4.3.0",
     "find-cache-dir": "^3.3.1",
     "fs-extra": "^8.1.0",
     "globby": "^6.1.0"

--- a/test/lib/index.spec.js
+++ b/test/lib/index.spec.js
@@ -1,0 +1,46 @@
+const path = require('path');
+const assert = require('../helper').assert;
+const index = require('../../lib/index');
+
+describe('index', () => {
+  describe('getCacheDir()', () => {
+    it('works for git@github.com:<username>/<project>.git', () => {
+      const dir = index.getCacheDir(
+        'git@github.com:example-user/example-project.git'
+      );
+
+      const expected = path.join(
+        '.cache',
+        'gh-pages',
+        'git@github.com!example-user!example-project.git'
+      );
+      assert(dir.endsWith(expected), `unexpected cache dir: ${dir}`);
+    });
+
+    it('works for https://github.com/<username>/<project>.git', () => {
+      const dir = index.getCacheDir(
+        'https://github.com/example-user/example-project.git'
+      );
+
+      const expected = path.join(
+        '.cache',
+        'gh-pages',
+        'https!github.com!example-user!example-project.git'
+      );
+      assert(dir.endsWith(expected), `unexpected cache dir: ${dir}`);
+    });
+
+    it('works for https://<username>:<password>@github.com/<username>/<project>.git', () => {
+      const dir = index.getCacheDir(
+        'https://user:pass@github.com/example-user/example-project.git'
+      );
+
+      const expected = path.join(
+        '.cache',
+        'gh-pages',
+        'https!user!pass@github.com!example-user!example-project.git'
+      );
+      assert(dir.endsWith(expected), `unexpected cache dir: ${dir}`);
+    });
+  });
+});


### PR DESCRIPTION
to prevent URL check failures blocking publishing.

related #394 #392

As my finding ( https://github.com/tschaub/gh-pages/issues/394#issuecomment-861920146 ) that `filenamify-url` is doing URL check but git repo URLs may fail the check and this dependency is only used to generate cache filename. I think it is safe to use only `filenamify`.

Fixes #392.