### PR TITLE
Custom Domain README fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -393,7 +393,7 @@ If `gh-pages` fails, you may find that you need to manually clean up the cache d
 Modify the deployment line to your deploy script if you use custom domain. This will prevent the deployment from removing the domain settings in GitHub.
 
 ```
-echo 'your_cutom_domain.online' > ./build/CNAME && gh-pages -d build"
+echo your_cutom_domain.online > ./build/CNAME && gh-pages -d build
 ```
 
 ### Deploying with GitHub Actions


### PR DESCRIPTION
The single quotes around the custom domain will be misinterpreted by GitHub and the desired action may not work due to incorrect domain
The CNAME file had saved with the below text
```
'your_cutom_domain.online'
```

The required CNAME file by the GitHub
```
your_cutom_domain.online
```
And also removed extra double quotes at the end