### PR TITLE
feat: add gpg signingkey option

### DIFF
--- a/bin/gh-pages.js
+++ b/bin/gh-pages.js
@@ -60,6 +60,10 @@ function main(args) {
         'The name and email of the user (defaults to the git config).  Format is "Your Name <email@example.com>".'
       )
       .option(
+        '--signingkey <signingkey>',
+        'The signing key for signing the commits (defaults to the git config).'
+      )
+      .option(
         '-v, --remove <pattern>',
         'Remove files that match the given pattern ' +
           '(ignored if used together with --add).',
@@ -122,6 +126,7 @@ function main(args) {
       push: !!program.push,
       history: !!program.history,
       user: user,
+      signingkey: program.signingkey,
       beforeAdd: beforeAdd
     };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -114,7 +114,10 @@ exports.publish = function publish(basePath, config, callback) {
   let repoUrl;
   let userPromise;
   if (options.user) {
-    userPromise = Promise.resolve(options.user);
+    userPromise = Promise.resolve({
+      ...options.user,
+      signingkey: options.signingkey
+    });
   } else {
     userPromise = getUser();
   }
@@ -205,7 +208,12 @@ exports.publish = function publish(basePath, config, callback) {
           if (!user.name) {
             return git;
           }
-          return git.exec('config', 'user.name', user.name);
+          return git.exec('config', 'user.name', user.name).then(() => {
+            if (!user.signingkey) {
+              return git;
+            }
+            return git.exec('config', 'user.signingkey', user.signingkey);
+          });
         });
       })
       .then(git => {

--- a/lib/util.js
+++ b/lib/util.js
@@ -157,10 +157,15 @@ exports.copy = function(files, base, dest) {
 exports.getUser = function(cwd) {
   return Promise.all([
     new Git(cwd).exec('config', 'user.name'),
-    new Git(cwd).exec('config', 'user.email')
+    new Git(cwd).exec('config', 'user.email'),
+    new Git(cwd).exec('config', 'user.signingkey')
   ])
     .then(results => {
-      return {name: results[0].output.trim(), email: results[1].output.trim()};
+      return {
+        name: results[0].output.trim(),
+        email: results[1].output.trim(),
+        signingkey: results[2].output.trim()
+      };
     })
     .catch(err => {
       // git config exits with 1 if name or email is not set

--- a/readme.md
+++ b/readme.md
@@ -216,7 +216,7 @@ ghpages.publish('dist', {
  * type: `Object`
  * default: `null`
 
-If you are running the `gh-pages` task in a repository without a `user.name` or `user.email` git config properties (or on a machine without these global config properties), you must provide user info before git allows you to commit.  The `options.user` object accepts `name` and `email` string values to identify the committer.
+If you are running the `gh-pages` task in a repository without a `user.name`, `user.email` or `user.signingkey` git config properties (or on a machine without these global config properties), you must provide user info before git allows you to commit.  The `options.user` object accepts `name`, `email` and `signingkey` string values to identify the committer.
 
 Example use of the `user` option:
 
@@ -224,7 +224,8 @@ Example use of the `user` option:
 ghpages.publish('dist', {
   user: {
     name: 'Joe Code',
-    email: 'coder@example.com'
+    email: 'coder@example.com',
+    signingkey: 'D29XXXXXXXXXXXXX'
   }
 }, callback);
 ```


### PR DESCRIPTION
Adding this option will allow us to set a local gpg signing key instead of always using the global configured key.