### PR TITLE
readme: Cleanup script requires .js

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -386,7 +386,7 @@ Note that this plugin requires Git 1.9 or higher (because it uses the `--exit-co
 
 The `gh-pages` module writes temporary files to a `node_modules/.cache/gh-pages` directory.  The location of this directory can be customized by setting the `CACHE_DIR` environment variable.
 
-If `gh-pages` fails, you may find that you need to manually clean up the cache directory.  To remove the cache directory, run `node_modules/gh-pages/bin/gh-pages-clean` or remove `node_modules/.cache/gh-pages`.
+If `gh-pages` fails, you may find that you need to manually clean up the cache directory.  To remove the cache directory, run `node_modules/gh-pages/bin/gh-pages-clean.js` or remove with `node_modules/.cache/gh-pages`.
 
 ### Deploying to github pages with custom domain
 


### PR DESCRIPTION
For me, the cleanup script needs to be run with `.js` extension. Is there a situation when it works without the `.js`?

```
$ node_modules/gh-pages/bin/gh-pages-clean   
zsh: no such file or directory: node_modules/gh-pages/bin/gh-pages-clean
$ node_modules/gh-pages/bin/gh-pages-clean.js
$ # no error indicates it worked
```

---

Regardless of this change, a success-message by this script would be great as well :).