### PR TITLE
Add error message when --dist is not specified.

### DIFF
--- a/bin/gh-pages.js
+++ b/bin/gh-pages.js
@@ -1,13 +1,20 @@
 #!/usr/bin/env node
 
 const ghpages = require('../lib/index.js');
-const program = require('commander');
+const {Command} = require('commander');
 const path = require('path');
 const pkg = require('../package.json');
 const addr = require('email-addresses');
 
-function publish(config) {
+function publish(program, config) {
   return new Promise((resolve, reject) => {
+    if (program.dist === undefined) {
+      return reject(
+        new Error(
+          'No base directory specified. The `--dist` option must be specified.'
+        )
+      );
+    }
     const basePath = path.resolve(process.cwd(), program.dist);
     ghpages.publish(basePath, config, (err) => {
       if (err) {
@@ -20,7 +27,7 @@ function publish(config) {
 
 function main(args) {
   return Promise.resolve().then(() => {
-    program
+    const program = new Command()
       .version(pkg.version)
       .option('-d, --dist <dist>', 'Base directory for all source files')
       .option(
@@ -125,7 +132,7 @@ function main(args) {
       beforeAdd: beforeAdd,
     };
 
-    return publish(config);
+    return publish(program, config);
   });
 }
 

--- a/test/bin/gh-pages.spec.js
+++ b/test/bin/gh-pages.spec.js
@@ -88,6 +88,11 @@ describe('gh-pages', () => {
         error:
           'Could not parse name and email from user option "junk email" (format should be "Your Name <email@example.com>")',
       },
+      {
+        args: ['.'],
+        error:
+          'No base directory specified. The `--dist` option must be specified.',
+      },
     ];
 
     scenarios.forEach(({args, dist, config, error}) => {


### PR DESCRIPTION
Fixes #354 by adding a descriptive message.

#### Previous behaviour
```bash
❯ npx gh-pages .
The "paths[1]" argument must be of type string. Received undefined
```

#### New behaviour
```bash
❯ npx gh-pages .
No base directory specified. The `--dist` option must be specified.
```

#### Other notes
I also used `Command()` instead of the singleton `CommanderStatic`, since it makes it more testable.
With `const program = require('commander');`, values like `program.user` were being carried from previous tests 👍 
