### PR TITLE
fix: Add missing cname option not passed to the config

### DIFF
--- a/bin/gh-pages.js
+++ b/bin/gh-pages.js
@@ -127,6 +127,7 @@ function main(args) {
       depth: options.depth,
       dotfiles: !!options.dotfiles,
       nojekyll: !!options.nojekyll,
+      cname: options.cname,
       add: !!options.add,
       remove: options.remove,
       remote: options.remote,

--- a/lib/index.js
+++ b/lib/index.js
@@ -183,13 +183,15 @@ exports.publish = function publish(basePath, config, callback) {
         }
       })
       .then((git) => {
-        log('Copying files');
         if (options.nojekyll) {
+          log('Creating .nojekyll');
           fs.createFileSync(path.join(git.cwd, '.nojekyll'));
         }
         if (options.cname) {
+          log('Creating CNAME for %s', options.cname);
           fs.writeFileSync(path.join(git.cwd, 'CNAME'), options.cname);
         }
+        log('Copying files');
         return copy(files, basePath, path.join(git.cwd, options.dest)).then(
           function () {
             return git;

--- a/test/bin/gh-pages.spec.js
+++ b/test/bin/gh-pages.spec.js
@@ -48,6 +48,11 @@ describe('gh-pages', () => {
         config: {nojekyll: true},
       },
       {
+        args: ['--dist', 'lib', '--cname', 'CNAME'],
+        dist: 'lib',
+        config: {cname: 'CNAME'},
+      },
+      {
         args: ['--dist', 'lib', '--dest', 'target'],
         dist: 'lib',
         config: {dest: 'target'},

--- a/test/integration/cnameExists.spec.js
+++ b/test/integration/cnameExists.spec.js
@@ -1,0 +1,38 @@
+const helper = require('../helper.js');
+const ghPages = require('../../lib/index.js');
+const path = require('path');
+
+const fixtures = path.join(__dirname, 'fixtures');
+const fixtureName = 'cname-exists';
+
+beforeEach(() => {
+  ghPages.clean();
+});
+
+describe('the --cname option', () => {
+  it('works even if the CNAME file already exists AND replaces any existing value', (done) => {
+    const local = path.join(fixtures, fixtureName, 'local');
+    const expected = path.join(fixtures, fixtureName, 'expected');
+    const branch = 'gh-pages';
+
+    helper.setupRemote(fixtureName, {branch}).then((url) => {
+      const options = {
+        repo: url,
+        user: {
+          name: 'User Name',
+          email: 'user@email.com',
+        },
+        cname: 'custom-domain.com',
+      };
+      ghPages.publish(local, options, (err) => {
+        if (err) {
+          return done(err);
+        }
+        helper
+          .assertContentsMatch(expected, url, branch)
+          .then(() => done())
+          .catch(done);
+      });
+    });
+  });
+});

--- a/test/integration/fixtures/cname-exists/expected/CNAME
+++ b/test/integration/fixtures/cname-exists/expected/CNAME
@@ -1,0 +1,1 @@
+custom-domain.com

--- a/test/integration/fixtures/cname-exists/expected/hello-world.txt
+++ b/test/integration/fixtures/cname-exists/expected/hello-world.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/test/integration/fixtures/cname-exists/local/hello-world.txt
+++ b/test/integration/fixtures/cname-exists/local/hello-world.txt
@@ -1,0 +1,1 @@
+Hello World!

--- a/test/integration/fixtures/cname-exists/remote/CNAME
+++ b/test/integration/fixtures/cname-exists/remote/CNAME
@@ -1,0 +1,1 @@
+existing-domain.com


### PR DESCRIPTION
The `--cname <CNAME>` option added in #533 is not passed to the config, thus this option doesn't work in the current release. This includes that option and adds a test for the missing case.

Reviewing the original PR, the only other difference I see is that there's a `nojekyll-exists` spec but not a `cname-exists` spec - if there's a desire to have that as well I can add it.