### PR TITLE
Make sure to pass options.cname

### DIFF
--- a/bin/gh-pages.js
+++ b/bin/gh-pages.js
@@ -134,6 +134,7 @@ function main(args) {
       history: !!options.history,
       user: user,
       beforeAdd: beforeAdd,
+      cname: options.cname,
     };
 
     return publish(options.dist, config);

--- a/lib/index.js
+++ b/lib/index.js
@@ -183,13 +183,15 @@ exports.publish = function publish(basePath, config, callback) {
         }
       })
       .then((git) => {
-        log('Copying files');
         if (options.nojekyll) {
+          log('Creating .nojekyll');
           fs.createFileSync(path.join(git.cwd, '.nojekyll'));
         }
         if (options.cname) {
+          log('Writing "%s" to CNAME', options.cname);
           fs.writeFileSync(path.join(git.cwd, 'CNAME'), options.cname);
         }
+        log('Copying files');
         return copy(files, basePath, path.join(git.cwd, options.dest)).then(
           function () {
             return git;


### PR DESCRIPTION
## Change

1. Make sure to pass `options.cname` to `publish()`.
2. Add debug lines for `.nojekyll` and `CNAME`.


## Problem / Why

`CNAME` file is not created when using `--cname` command option.