### PR TITLE
fix: include dotfiles in the deployment by default

### DIFF
--- a/bin/gh-pages.js
+++ b/bin/gh-pages.js
@@ -50,7 +50,7 @@ function main(args) {
       )
       .option('-g, --tag <tag>', 'add tag to commit')
       .option('--git <git>', 'Path to git executable', ghpages.defaults.git)
-      .option('-t, --dotfiles', 'Include dotfiles')
+      .option('-t, --dotfiles', 'Include dotfiles', ghpages.defaults.dotfiles)
       .option('--nojekyll', 'Add a .nojekyll file to disable Jekyll')
       .option(
         '--cname <CNAME>',

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,7 +39,7 @@ exports.defaults = {
   add: false,
   git: 'git',
   depth: 1,
-  dotfiles: false,
+  dotfiles: true,
   branch: 'gh-pages',
   remote: 'origin',
   src: '**/*',


### PR DESCRIPTION
Whenever a user specifies a directory, they expect the dotfiles to be served as they exist on the file system. No web standards or conventions specifies otherwise. The previous default was surprising and as you see in the issue #315, has caused issues for many users.

This PR changes the default to true making this behaviour opt-in.