### PR TITLE
window Error: spawn ENAMETOOLONG error 

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -1,8 +1,8 @@
-const cp = require("child_process");
-const fs = require("fs-extra");
-const path = require("path");
-const util = require("util");
-const os = require("os");
+const cp = require('child_process');
+const fs = require('fs-extra');
+const path = require('path');
+const util = require('util');
+const os = require('os');
 
 /**
  * @function Object() { [native code] }
@@ -28,18 +28,18 @@ util.inherits(ProcessError, Error);
  */
 function spawn(exe, args, cwd) {
   return new Promise((resolve, reject) => {
-    const child = cp.spawn(exe, args, { cwd: cwd || process.cwd() });
+    const child = cp.spawn(exe, args, {cwd: cwd || process.cwd()});
     const buffer = [];
-    child.stderr.on("data", (chunk) => {
+    child.stderr.on('data', (chunk) => {
       buffer.push(chunk.toString());
     });
-    child.stdout.on("data", (chunk) => {
+    child.stdout.on('data', (chunk) => {
       buffer.push(chunk.toString());
     });
-    child.on("close", (code) => {
-      const output = buffer.join("");
+    child.on('close', (code) => {
+      const output = buffer.join('');
       if (code) {
-        const msg = output || "Process failed: " + code;
+        const msg = output || 'Process failed: ' + code;
         reject(new ProcessError(code, msg));
       } else {
         resolve(output);
@@ -56,8 +56,8 @@ function spawn(exe, args, cwd) {
  */
 function Git(cwd, cmd) {
   this.cwd = cwd;
-  this.cmd = cmd || "git";
-  this.output = "";
+  this.cmd = cmd || 'git';
+  this.output = '';
 }
 
 /**
@@ -78,7 +78,7 @@ Git.prototype.exec = function (...args) {
  * @return {Promise} A promise.
  */
 Git.prototype.init = function () {
-  return this.exec("init");
+  return this.exec('init');
 };
 
 /**
@@ -86,7 +86,7 @@ Git.prototype.init = function () {
  * @return {Promise} A promise.
  */
 Git.prototype.clean = function () {
-  return this.exec("clean", "-f", "-d");
+  return this.exec('clean', '-f', '-d');
 };
 
 /**
@@ -96,7 +96,7 @@ Git.prototype.clean = function () {
  * @return {Promise} A promise.
  */
 Git.prototype.reset = function (remote, branch) {
-  return this.exec("reset", "--hard", remote + "/" + branch);
+  return this.exec('reset', '--hard', remote + '/' + branch);
 };
 
 /**
@@ -105,7 +105,7 @@ Git.prototype.reset = function (remote, branch) {
  * @return {Promise} A promise.
  */
 Git.prototype.fetch = function (remote) {
-  return this.exec("fetch", remote);
+  return this.exec('fetch', remote);
 };
 
 /**
@@ -115,18 +115,18 @@ Git.prototype.fetch = function (remote) {
  * @return {Promise} A promise.
  */
 Git.prototype.checkout = function (remote, branch) {
-  const treeish = remote + "/" + branch;
-  return this.exec("ls-remote", "--exit-code", ".", treeish).then(
+  const treeish = remote + '/' + branch;
+  return this.exec('ls-remote', '--exit-code', '.', treeish).then(
     () => {
       // branch exists on remote, hard reset
-      return this.exec("checkout", branch)
+      return this.exec('checkout', branch)
         .then(() => this.clean())
         .then(() => this.reset(remote, branch));
     },
     (error) => {
       if (error instanceof ProcessError && error.code === 2) {
         // branch doesn't exist, create an orphan
-        return this.exec("checkout", "--orphan", branch);
+        return this.exec('checkout', '--orphan', branch);
       } else {
         // unhandled error
         throw error;
@@ -145,41 +145,44 @@ Git.prototype.rm = function (files) {
     files = [files];
   }
 
-  if (os.platform() === "win32") {
+  if(os.platform() ==='win32'){
     return separateRm(this, files);
-  } else {
-    return this.exec("rm", "--ignore-unmatch", "-r", "-f", ...files);
+  } else{
+    return this.exec('rm', '--ignore-unmatch', '-r', '-f', ...files);
   }
 };
 
 /**
  * files separate deletion
- *
+ * 
  * @param {Git} thisObj git
  * @param {Array} files files Files argument
- * @returns
+ * @returns 
  */
-async function separateRm(thisObj, files) {
+async function separateRm (thisObj , files ) {
+
   const limitFileCount = 100;
   const fileLength = files.length;
-  let loopCount = Math.ceil(fileLength / limitFileCount);
+  let loopCount = Math.ceil(fileLength /limitFileCount);
 
   let startIdx = 0;
-  const allExecResult = [];
-  let endIdx = limitFileCount;
-  for (let i = 0; i < loopCount; i++) {
-    if (endIdx > fileLength) {
-      endIdx = fileLength - 1;
+  const allExecResult =[];
+  let endIdx =limitFileCount; 
+  for(let i =0;i <loopCount; i++){
+
+    if(endIdx > fileLength){
+      endIdx = fileLength-1;
     }
 
     let rmFiles = files.slice(startIdx, endIdx);
-    allExecResult.push(await thisObj.exec("rm", "--ignore-unmatch", "-r", "-f", ...rmFiles));
-    startIdx = endIdx;
-    endIdx = endIdx + limitFileCount;
+    allExecResult.push(await thisObj.exec('rm', '--ignore-unmatch', '-r', '-f', ...rmFiles));
+    startIdx  = endIdx;
+    endIdx = endIdx+ limitFileCount;
   }
 
-  return allExecResult[allExecResult.length - 1];
+  return allExecResult[allExecResult.length-1];
 }
+
 
 /**
  * Add files.
@@ -190,7 +193,7 @@ Git.prototype.add = function (files) {
   if (!Array.isArray(files)) {
     files = [files];
   }
-  return this.exec("add", ...files);
+  return this.exec('add', ...files);
 };
 
 /**
@@ -199,7 +202,9 @@ Git.prototype.add = function (files) {
  * @return {Promise} A promise.
  */
 Git.prototype.commit = function (message) {
-  return this.exec("diff-index", "--quiet", "HEAD").catch(() => this.exec("commit", "-m", message));
+  return this.exec('diff-index', '--quiet', 'HEAD').catch(() =>
+    this.exec('commit', '-m', message)
+  );
 };
 
 /**
@@ -208,7 +213,7 @@ Git.prototype.commit = function (message) {
  * @return {Promise} A promise.
  */
 Git.prototype.tag = function (name) {
-  return this.exec("tag", name);
+  return this.exec('tag', name);
 };
 
 /**
@@ -219,9 +224,9 @@ Git.prototype.tag = function (name) {
  * @return {Promise} A promise.
  */
 Git.prototype.push = function (remote, branch, force) {
-  const args = ["push", "--tags", remote, branch];
+  const args = ['push', '--tags', remote, branch];
   if (force) {
-    args.push("--force");
+    args.push('--force');
   }
   return this.exec.apply(this, args);
 };
@@ -232,17 +237,27 @@ Git.prototype.push = function (remote, branch, force) {
  * @return {Promise<string>} A promise for the remote URL.
  */
 Git.prototype.getRemoteUrl = function (remote) {
-  return this.exec("config", "--get", "remote." + remote + ".url")
+  return this.exec('config', '--get', 'remote.' + remote + '.url')
     .then((git) => {
       const repo = git.output && git.output.split(/[\n\r]/).shift();
       if (repo) {
         return repo;
       } else {
-        throw new Error("Failed to get repo URL from options or current directory.");
+        throw new Error(
+          'Failed to get repo URL from options or current directory.'
+        );
       }
     })
     .catch((err) => {
-      throw new Error("Failed to get remote." + remote + ".url (task must either be " + "run in a git repository with a configured " + remote + " remote " + 'or must be configured with the "repo" option).');
+      throw new Error(
+        'Failed to get remote.' +
+          remote +
+          '.url (task must either be ' +
+          'run in a git repository with a configured ' +
+          remote +
+          ' remote ' +
+          'or must be configured with the "repo" option).'
+      );
     });
 };
 
@@ -253,7 +268,7 @@ Git.prototype.getRemoteUrl = function (remote) {
  *     or rejected with an error.
  */
 Git.prototype.deleteRef = function (branch) {
-  return this.exec("update-ref", "-d", "refs/heads/" + branch);
+  return this.exec('update-ref', '-d', 'refs/heads/' + branch);
 };
 
 /**
@@ -270,11 +285,28 @@ Git.clone = function clone(repo, dir, branch, options) {
       return Promise.resolve(new Git(dir, options.git));
     } else {
       return fs.mkdirp(path.dirname(path.resolve(dir))).then(() => {
-        const args = ["clone", repo, dir, "--branch", branch, "--single-branch", "--origin", options.remote, "--depth", options.depth];
+        const args = [
+          'clone',
+          repo,
+          dir,
+          '--branch',
+          branch,
+          '--single-branch',
+          '--origin',
+          options.remote,
+          '--depth',
+          options.depth,
+        ];
         return spawn(options.git, args)
           .catch((err) => {
             // try again without branch or depth options
-            return spawn(options.git, ["clone", repo, dir, "--origin", options.remote]);
+            return spawn(options.git, [
+              'clone',
+              repo,
+              dir,
+              '--origin',
+              options.remote,
+            ]);
           })
           .then(() => new Git(dir, options.git));
       });

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,7 +1,8 @@
-const cp = require('child_process');
-const fs = require('fs-extra');
-const path = require('path');
-const util = require('util');
+const cp = require("child_process");
+const fs = require("fs-extra");
+const path = require("path");
+const util = require("util");
+const os = require("os");
 
 /**
  * @function Object() { [native code] }
@@ -9,12 +10,12 @@ const util = require('util');
  * @param {string} message Error message.
  */
 function ProcessError(code, message) {
-  const callee = arguments.callee;
-  Error.apply(this, [message]);
-  Error.captureStackTrace(this, callee);
-  this.code = code;
-  this.message = message;
-  this.name = callee.name;
+    const callee = arguments.callee;
+    Error.apply(this, [message]);
+    Error.captureStackTrace(this, callee);
+    this.code = code;
+    this.message = message;
+    this.name = callee.name;
 }
 util.inherits(ProcessError, Error);
 
@@ -26,25 +27,25 @@ util.inherits(ProcessError, Error);
  * @return {Promise} A promise.
  */
 function spawn(exe, args, cwd) {
-  return new Promise((resolve, reject) => {
-    const child = cp.spawn(exe, args, {cwd: cwd || process.cwd()});
-    const buffer = [];
-    child.stderr.on('data', (chunk) => {
-      buffer.push(chunk.toString());
+    return new Promise((resolve, reject) => {
+        const child = cp.spawn(exe, args, { cwd: cwd || process.cwd() });
+        const buffer = [];
+        child.stderr.on("data", (chunk) => {
+            buffer.push(chunk.toString());
+        });
+        child.stdout.on("data", (chunk) => {
+            buffer.push(chunk.toString());
+        });
+        child.on("close", (code) => {
+            const output = buffer.join("");
+            if (code) {
+                const msg = output || "Process failed: " + code;
+                reject(new ProcessError(code, msg));
+            } else {
+                resolve(output);
+            }
+        });
     });
-    child.stdout.on('data', (chunk) => {
-      buffer.push(chunk.toString());
-    });
-    child.on('close', (code) => {
-      const output = buffer.join('');
-      if (code) {
-        const msg = output || 'Process failed: ' + code;
-        reject(new ProcessError(code, msg));
-      } else {
-        resolve(output);
-      }
-    });
-  });
 }
 
 /**
@@ -54,9 +55,9 @@ function spawn(exe, args, cwd) {
  * @function Object() { [native code] }
  */
 function Git(cwd, cmd) {
-  this.cwd = cwd;
-  this.cmd = cmd || 'git';
-  this.output = '';
+    this.cwd = cwd;
+    this.cmd = cmd || "git";
+    this.output = "";
 }
 
 /**
@@ -66,10 +67,10 @@ function Git(cwd, cmd) {
  *     or rejected with an error.
  */
 Git.prototype.exec = function (...args) {
-  return spawn(this.cmd, [...args], this.cwd).then((output) => {
-    this.output = output;
-    return this;
-  });
+    return spawn(this.cmd, [...args], this.cwd).then((output) => {
+        this.output = output;
+        return this;
+    });
 };
 
 /**
@@ -77,7 +78,7 @@ Git.prototype.exec = function (...args) {
  * @return {Promise} A promise.
  */
 Git.prototype.init = function () {
-  return this.exec('init');
+    return this.exec("init");
 };
 
 /**
@@ -85,7 +86,7 @@ Git.prototype.init = function () {
  * @return {Promise} A promise.
  */
 Git.prototype.clean = function () {
-  return this.exec('clean', '-f', '-d');
+    return this.exec("clean", "-f", "-d");
 };
 
 /**
@@ -95,7 +96,7 @@ Git.prototype.clean = function () {
  * @return {Promise} A promise.
  */
 Git.prototype.reset = function (remote, branch) {
-  return this.exec('reset', '--hard', remote + '/' + branch);
+    return this.exec("reset", "--hard", remote + "/" + branch);
 };
 
 /**
@@ -104,7 +105,7 @@ Git.prototype.reset = function (remote, branch) {
  * @return {Promise} A promise.
  */
 Git.prototype.fetch = function (remote) {
-  return this.exec('fetch', remote);
+    return this.exec("fetch", remote);
 };
 
 /**
@@ -114,24 +115,24 @@ Git.prototype.fetch = function (remote) {
  * @return {Promise} A promise.
  */
 Git.prototype.checkout = function (remote, branch) {
-  const treeish = remote + '/' + branch;
-  return this.exec('ls-remote', '--exit-code', '.', treeish).then(
-    () => {
-      // branch exists on remote, hard reset
-      return this.exec('checkout', branch)
-        .then(() => this.clean())
-        .then(() => this.reset(remote, branch));
-    },
-    (error) => {
-      if (error instanceof ProcessError && error.code === 2) {
-        // branch doesn't exist, create an orphan
-        return this.exec('checkout', '--orphan', branch);
-      } else {
-        // unhandled error
-        throw error;
-      }
-    }
-  );
+    const treeish = remote + "/" + branch;
+    return this.exec("ls-remote", "--exit-code", ".", treeish).then(
+        () => {
+            // branch exists on remote, hard reset
+            return this.exec("checkout", branch)
+                .then(() => this.clean())
+                .then(() => this.reset(remote, branch));
+        },
+        (error) => {
+            if (error instanceof ProcessError && error.code === 2) {
+                // branch doesn't exist, create an orphan
+                return this.exec("checkout", "--orphan", branch);
+            } else {
+                // unhandled error
+                throw error;
+            }
+        }
+    );
 };
 
 /**
@@ -140,11 +141,45 @@ Git.prototype.checkout = function (remote, branch) {
  * @return {Promise} A promise.
  */
 Git.prototype.rm = function (files) {
-  if (!Array.isArray(files)) {
-    files = [files];
-  }
-  return this.exec('rm', '--ignore-unmatch', '-r', '-f', ...files);
+    if (!Array.isArray(files)) {
+        files = [files];
+    }
+
+    if (os.platform() === "win32") {
+        return separateRm(this, files);
+    } else {
+        return this.exec("rm", "--ignore-unmatch", "-r", "-f", ...files);
+    }
 };
+
+/**
+ * files separate deletion
+ *
+ * @param {Git} thisObj git
+ * @param {Array} files files Files argument
+ * @returns
+ */
+async function separateRm(thisObj, files) {
+    const limitFileCount = 100;
+    const fileLength = files.length;
+    let loopCount = Math.ceil(fileLength / limitFileCount);
+
+    let startIdx = 0;
+    const allExecResult = [];
+    let endIdx = limitFileCount;
+    for (let i = 0; i < loopCount; i++) {
+        if (endIdx > fileLength) {
+            endIdx = fileLength - 1;
+        }
+
+        let rmFiles = files.slice(startIdx, endIdx);
+        allExecResult.push(await thisObj.exec("rm", "--ignore-unmatch", "-r", "-f", ...rmFiles));
+        startIdx = endIdx;
+        endIdx = endIdx + limitFileCount;
+    }
+
+    return allExecResult[allExecResult.length - 1];
+}
 
 /**
  * Add files.
@@ -152,10 +187,10 @@ Git.prototype.rm = function (files) {
  * @return {Promise} A promise.
  */
 Git.prototype.add = function (files) {
-  if (!Array.isArray(files)) {
-    files = [files];
-  }
-  return this.exec('add', ...files);
+    if (!Array.isArray(files)) {
+        files = [files];
+    }
+    return this.exec("add", ...files);
 };
 
 /**
@@ -164,9 +199,7 @@ Git.prototype.add = function (files) {
  * @return {Promise} A promise.
  */
 Git.prototype.commit = function (message) {
-  return this.exec('diff-index', '--quiet', 'HEAD').catch(() =>
-    this.exec('commit', '-m', message)
-  );
+    return this.exec("diff-index", "--quiet", "HEAD").catch(() => this.exec("commit", "-m", message));
 };
 
 /**
@@ -175,7 +208,7 @@ Git.prototype.commit = function (message) {
  * @return {Promise} A promise.
  */
 Git.prototype.tag = function (name) {
-  return this.exec('tag', name);
+    return this.exec("tag", name);
 };
 
 /**
@@ -186,11 +219,11 @@ Git.prototype.tag = function (name) {
  * @return {Promise} A promise.
  */
 Git.prototype.push = function (remote, branch, force) {
-  const args = ['push', '--tags', remote, branch];
-  if (force) {
-    args.push('--force');
-  }
-  return this.exec.apply(this, args);
+    const args = ["push", "--tags", remote, branch];
+    if (force) {
+        args.push("--force");
+    }
+    return this.exec.apply(this, args);
 };
 
 /**
@@ -199,28 +232,18 @@ Git.prototype.push = function (remote, branch, force) {
  * @return {Promise<string>} A promise for the remote URL.
  */
 Git.prototype.getRemoteUrl = function (remote) {
-  return this.exec('config', '--get', 'remote.' + remote + '.url')
-    .then((git) => {
-      const repo = git.output && git.output.split(/[\n\r]/).shift();
-      if (repo) {
-        return repo;
-      } else {
-        throw new Error(
-          'Failed to get repo URL from options or current directory.'
-        );
-      }
-    })
-    .catch((err) => {
-      throw new Error(
-        'Failed to get remote.' +
-          remote +
-          '.url (task must either be ' +
-          'run in a git repository with a configured ' +
-          remote +
-          ' remote ' +
-          'or must be configured with the "repo" option).'
-      );
-    });
+    return this.exec("config", "--get", "remote." + remote + ".url")
+        .then((git) => {
+            const repo = git.output && git.output.split(/[\n\r]/).shift();
+            if (repo) {
+                return repo;
+            } else {
+                throw new Error("Failed to get repo URL from options or current directory.");
+            }
+        })
+        .catch((err) => {
+            throw new Error("Failed to get remote." + remote + ".url (task must either be " + "run in a git repository with a configured " + remote + " remote " + 'or must be configured with the "repo" option).');
+        });
 };
 
 /**
@@ -230,7 +253,7 @@ Git.prototype.getRemoteUrl = function (remote) {
  *     or rejected with an error.
  */
 Git.prototype.deleteRef = function (branch) {
-  return this.exec('update-ref', '-d', 'refs/heads/' + branch);
+    return this.exec("update-ref", "-d", "refs/heads/" + branch);
 };
 
 /**
@@ -242,38 +265,21 @@ Git.prototype.deleteRef = function (branch) {
  * @return {Promise<Git>} A promise.
  */
 Git.clone = function clone(repo, dir, branch, options) {
-  return fs.exists(dir).then((exists) => {
-    if (exists) {
-      return Promise.resolve(new Git(dir, options.git));
-    } else {
-      return fs.mkdirp(path.dirname(path.resolve(dir))).then(() => {
-        const args = [
-          'clone',
-          repo,
-          dir,
-          '--branch',
-          branch,
-          '--single-branch',
-          '--origin',
-          options.remote,
-          '--depth',
-          options.depth,
-        ];
-        return spawn(options.git, args)
-          .catch((err) => {
-            // try again without branch or depth options
-            return spawn(options.git, [
-              'clone',
-              repo,
-              dir,
-              '--origin',
-              options.remote,
-            ]);
-          })
-          .then(() => new Git(dir, options.git));
-      });
-    }
-  });
+    return fs.exists(dir).then((exists) => {
+        if (exists) {
+            return Promise.resolve(new Git(dir, options.git));
+        } else {
+            return fs.mkdirp(path.dirname(path.resolve(dir))).then(() => {
+                const args = ["clone", repo, dir, "--branch", branch, "--single-branch", "--origin", options.remote, "--depth", options.depth];
+                return spawn(options.git, args)
+                    .catch((err) => {
+                        // try again without branch or depth options
+                        return spawn(options.git, ["clone", repo, dir, "--origin", options.remote]);
+                    })
+                    .then(() => new Git(dir, options.git));
+            });
+        }
+    });
 };
 
 module.exports = Git;

--- a/lib/git.js
+++ b/lib/git.js
@@ -10,12 +10,12 @@ const os = require("os");
  * @param {string} message Error message.
  */
 function ProcessError(code, message) {
-    const callee = arguments.callee;
-    Error.apply(this, [message]);
-    Error.captureStackTrace(this, callee);
-    this.code = code;
-    this.message = message;
-    this.name = callee.name;
+  const callee = arguments.callee;
+  Error.apply(this, [message]);
+  Error.captureStackTrace(this, callee);
+  this.code = code;
+  this.message = message;
+  this.name = callee.name;
 }
 util.inherits(ProcessError, Error);
 
@@ -27,25 +27,25 @@ util.inherits(ProcessError, Error);
  * @return {Promise} A promise.
  */
 function spawn(exe, args, cwd) {
-    return new Promise((resolve, reject) => {
-        const child = cp.spawn(exe, args, { cwd: cwd || process.cwd() });
-        const buffer = [];
-        child.stderr.on("data", (chunk) => {
-            buffer.push(chunk.toString());
-        });
-        child.stdout.on("data", (chunk) => {
-            buffer.push(chunk.toString());
-        });
-        child.on("close", (code) => {
-            const output = buffer.join("");
-            if (code) {
-                const msg = output || "Process failed: " + code;
-                reject(new ProcessError(code, msg));
-            } else {
-                resolve(output);
-            }
-        });
+  return new Promise((resolve, reject) => {
+    const child = cp.spawn(exe, args, { cwd: cwd || process.cwd() });
+    const buffer = [];
+    child.stderr.on("data", (chunk) => {
+      buffer.push(chunk.toString());
     });
+    child.stdout.on("data", (chunk) => {
+      buffer.push(chunk.toString());
+    });
+    child.on("close", (code) => {
+      const output = buffer.join("");
+      if (code) {
+        const msg = output || "Process failed: " + code;
+        reject(new ProcessError(code, msg));
+      } else {
+        resolve(output);
+      }
+    });
+  });
 }
 
 /**
@@ -55,9 +55,9 @@ function spawn(exe, args, cwd) {
  * @function Object() { [native code] }
  */
 function Git(cwd, cmd) {
-    this.cwd = cwd;
-    this.cmd = cmd || "git";
-    this.output = "";
+  this.cwd = cwd;
+  this.cmd = cmd || "git";
+  this.output = "";
 }
 
 /**
@@ -67,10 +67,10 @@ function Git(cwd, cmd) {
  *     or rejected with an error.
  */
 Git.prototype.exec = function (...args) {
-    return spawn(this.cmd, [...args], this.cwd).then((output) => {
-        this.output = output;
-        return this;
-    });
+  return spawn(this.cmd, [...args], this.cwd).then((output) => {
+    this.output = output;
+    return this;
+  });
 };
 
 /**
@@ -78,7 +78,7 @@ Git.prototype.exec = function (...args) {
  * @return {Promise} A promise.
  */
 Git.prototype.init = function () {
-    return this.exec("init");
+  return this.exec("init");
 };
 
 /**
@@ -86,7 +86,7 @@ Git.prototype.init = function () {
  * @return {Promise} A promise.
  */
 Git.prototype.clean = function () {
-    return this.exec("clean", "-f", "-d");
+  return this.exec("clean", "-f", "-d");
 };
 
 /**
@@ -96,7 +96,7 @@ Git.prototype.clean = function () {
  * @return {Promise} A promise.
  */
 Git.prototype.reset = function (remote, branch) {
-    return this.exec("reset", "--hard", remote + "/" + branch);
+  return this.exec("reset", "--hard", remote + "/" + branch);
 };
 
 /**
@@ -105,7 +105,7 @@ Git.prototype.reset = function (remote, branch) {
  * @return {Promise} A promise.
  */
 Git.prototype.fetch = function (remote) {
-    return this.exec("fetch", remote);
+  return this.exec("fetch", remote);
 };
 
 /**
@@ -115,24 +115,24 @@ Git.prototype.fetch = function (remote) {
  * @return {Promise} A promise.
  */
 Git.prototype.checkout = function (remote, branch) {
-    const treeish = remote + "/" + branch;
-    return this.exec("ls-remote", "--exit-code", ".", treeish).then(
-        () => {
-            // branch exists on remote, hard reset
-            return this.exec("checkout", branch)
-                .then(() => this.clean())
-                .then(() => this.reset(remote, branch));
-        },
-        (error) => {
-            if (error instanceof ProcessError && error.code === 2) {
-                // branch doesn't exist, create an orphan
-                return this.exec("checkout", "--orphan", branch);
-            } else {
-                // unhandled error
-                throw error;
-            }
-        }
-    );
+  const treeish = remote + "/" + branch;
+  return this.exec("ls-remote", "--exit-code", ".", treeish).then(
+    () => {
+      // branch exists on remote, hard reset
+      return this.exec("checkout", branch)
+        .then(() => this.clean())
+        .then(() => this.reset(remote, branch));
+    },
+    (error) => {
+      if (error instanceof ProcessError && error.code === 2) {
+        // branch doesn't exist, create an orphan
+        return this.exec("checkout", "--orphan", branch);
+      } else {
+        // unhandled error
+        throw error;
+      }
+    }
+  );
 };
 
 /**
@@ -141,15 +141,15 @@ Git.prototype.checkout = function (remote, branch) {
  * @return {Promise} A promise.
  */
 Git.prototype.rm = function (files) {
-    if (!Array.isArray(files)) {
-        files = [files];
-    }
+  if (!Array.isArray(files)) {
+    files = [files];
+  }
 
-    if (os.platform() === "win32") {
-        return separateRm(this, files);
-    } else {
-        return this.exec("rm", "--ignore-unmatch", "-r", "-f", ...files);
-    }
+  if (os.platform() === "win32") {
+    return separateRm(this, files);
+  } else {
+    return this.exec("rm", "--ignore-unmatch", "-r", "-f", ...files);
+  }
 };
 
 /**
@@ -160,25 +160,25 @@ Git.prototype.rm = function (files) {
  * @returns
  */
 async function separateRm(thisObj, files) {
-    const limitFileCount = 100;
-    const fileLength = files.length;
-    let loopCount = Math.ceil(fileLength / limitFileCount);
+  const limitFileCount = 100;
+  const fileLength = files.length;
+  let loopCount = Math.ceil(fileLength / limitFileCount);
 
-    let startIdx = 0;
-    const allExecResult = [];
-    let endIdx = limitFileCount;
-    for (let i = 0; i < loopCount; i++) {
-        if (endIdx > fileLength) {
-            endIdx = fileLength - 1;
-        }
-
-        let rmFiles = files.slice(startIdx, endIdx);
-        allExecResult.push(await thisObj.exec("rm", "--ignore-unmatch", "-r", "-f", ...rmFiles));
-        startIdx = endIdx;
-        endIdx = endIdx + limitFileCount;
+  let startIdx = 0;
+  const allExecResult = [];
+  let endIdx = limitFileCount;
+  for (let i = 0; i < loopCount; i++) {
+    if (endIdx > fileLength) {
+      endIdx = fileLength - 1;
     }
 
-    return allExecResult[allExecResult.length - 1];
+    let rmFiles = files.slice(startIdx, endIdx);
+    allExecResult.push(await thisObj.exec("rm", "--ignore-unmatch", "-r", "-f", ...rmFiles));
+    startIdx = endIdx;
+    endIdx = endIdx + limitFileCount;
+  }
+
+  return allExecResult[allExecResult.length - 1];
 }
 
 /**
@@ -187,10 +187,10 @@ async function separateRm(thisObj, files) {
  * @return {Promise} A promise.
  */
 Git.prototype.add = function (files) {
-    if (!Array.isArray(files)) {
-        files = [files];
-    }
-    return this.exec("add", ...files);
+  if (!Array.isArray(files)) {
+    files = [files];
+  }
+  return this.exec("add", ...files);
 };
 
 /**
@@ -199,7 +199,7 @@ Git.prototype.add = function (files) {
  * @return {Promise} A promise.
  */
 Git.prototype.commit = function (message) {
-    return this.exec("diff-index", "--quiet", "HEAD").catch(() => this.exec("commit", "-m", message));
+  return this.exec("diff-index", "--quiet", "HEAD").catch(() => this.exec("commit", "-m", message));
 };
 
 /**
@@ -208,7 +208,7 @@ Git.prototype.commit = function (message) {
  * @return {Promise} A promise.
  */
 Git.prototype.tag = function (name) {
-    return this.exec("tag", name);
+  return this.exec("tag", name);
 };
 
 /**
@@ -219,11 +219,11 @@ Git.prototype.tag = function (name) {
  * @return {Promise} A promise.
  */
 Git.prototype.push = function (remote, branch, force) {
-    const args = ["push", "--tags", remote, branch];
-    if (force) {
-        args.push("--force");
-    }
-    return this.exec.apply(this, args);
+  const args = ["push", "--tags", remote, branch];
+  if (force) {
+    args.push("--force");
+  }
+  return this.exec.apply(this, args);
 };
 
 /**
@@ -232,18 +232,18 @@ Git.prototype.push = function (remote, branch, force) {
  * @return {Promise<string>} A promise for the remote URL.
  */
 Git.prototype.getRemoteUrl = function (remote) {
-    return this.exec("config", "--get", "remote." + remote + ".url")
-        .then((git) => {
-            const repo = git.output && git.output.split(/[\n\r]/).shift();
-            if (repo) {
-                return repo;
-            } else {
-                throw new Error("Failed to get repo URL from options or current directory.");
-            }
-        })
-        .catch((err) => {
-            throw new Error("Failed to get remote." + remote + ".url (task must either be " + "run in a git repository with a configured " + remote + " remote " + 'or must be configured with the "repo" option).');
-        });
+  return this.exec("config", "--get", "remote." + remote + ".url")
+    .then((git) => {
+      const repo = git.output && git.output.split(/[\n\r]/).shift();
+      if (repo) {
+        return repo;
+      } else {
+        throw new Error("Failed to get repo URL from options or current directory.");
+      }
+    })
+    .catch((err) => {
+      throw new Error("Failed to get remote." + remote + ".url (task must either be " + "run in a git repository with a configured " + remote + " remote " + 'or must be configured with the "repo" option).');
+    });
 };
 
 /**
@@ -253,7 +253,7 @@ Git.prototype.getRemoteUrl = function (remote) {
  *     or rejected with an error.
  */
 Git.prototype.deleteRef = function (branch) {
-    return this.exec("update-ref", "-d", "refs/heads/" + branch);
+  return this.exec("update-ref", "-d", "refs/heads/" + branch);
 };
 
 /**
@@ -265,21 +265,21 @@ Git.prototype.deleteRef = function (branch) {
  * @return {Promise<Git>} A promise.
  */
 Git.clone = function clone(repo, dir, branch, options) {
-    return fs.exists(dir).then((exists) => {
-        if (exists) {
-            return Promise.resolve(new Git(dir, options.git));
-        } else {
-            return fs.mkdirp(path.dirname(path.resolve(dir))).then(() => {
-                const args = ["clone", repo, dir, "--branch", branch, "--single-branch", "--origin", options.remote, "--depth", options.depth];
-                return spawn(options.git, args)
-                    .catch((err) => {
-                        // try again without branch or depth options
-                        return spawn(options.git, ["clone", repo, dir, "--origin", options.remote]);
-                    })
-                    .then(() => new Git(dir, options.git));
-            });
-        }
-    });
+  return fs.exists(dir).then((exists) => {
+    if (exists) {
+      return Promise.resolve(new Git(dir, options.git));
+    } else {
+      return fs.mkdirp(path.dirname(path.resolve(dir))).then(() => {
+        const args = ["clone", repo, dir, "--branch", branch, "--single-branch", "--origin", options.remote, "--depth", options.depth];
+        return spawn(options.git, args)
+          .catch((err) => {
+            // try again without branch or depth options
+            return spawn(options.git, ["clone", repo, dir, "--origin", options.remote]);
+          })
+          .then(() => new Git(dir, options.git));
+      });
+    }
+  });
 };
 
 module.exports = Git;


### PR DESCRIPTION
The error "window Error: spawn ENAMETOOLONG error" that occurs on Windows happens during the execution of Git.prototype.rm. To resolve this, the files are processed separately when performing the rm operation.