### PR TITLE
fixes #592

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -143,7 +143,7 @@ Git.prototype.rm = function (files) {
   if (!Array.isArray(files)) {
     files = [files];
   }
-  return this.exec('rm', '--ignore-unmatch', '-r', '-f', ...files);
+  return this.exec('rm', '--ignore-unmatch', '-r', '-f', '--', ...files);
 };
 
 /**


### PR DESCRIPTION
This fix ensures `gh-pages` correctly handles files with names starting with a `-`. By adding `--` to the `git rm` command, filenames are treated as file paths instead of options. This prevents errors during deployment.