### PR TITLE
[Bugfix] make default remove glob match dotfiles

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,7 @@ exports.defaults = {
   branch: 'gh-pages',
   remote: 'origin',
   src: '**/*',
-  remove: '.',
+  remove: '**/*',
   push: true,
   history: true,
   message: 'Updates',
@@ -182,6 +182,7 @@ exports.publish = function publish(basePath, config, callback) {
         const files = globby
           .sync(options.remove, {
             cwd: path.join(git.cwd, options.dest),
+            dot: true,
           })
           .map((file) => path.join(options.dest, file));
         if (files.length > 0) {

--- a/readme.md
+++ b/readme.md
@@ -258,9 +258,9 @@ ghpages.publish('dist', {
 }, callback);
 ```
 
-#### <a id="optionsuser">options.remove</a>
+#### <a id="optionsremove">options.remove</a>
  * type: `string`
- * default: `'.'`
+ * default: `'**/*'`
 
 Removes files that match the given pattern (Ignored if used together with
 `--add`). By default, `gh-pages` removes everything inside the target branch


### PR DESCRIPTION
#### What’s Changed

* Default option `remove` is changed from `'.'` to `'**/{,.}*'`.
* The new glob pattern matches ordinary files and dotfiles, guaranteeing a truly clean working directory before publishing.

#### Why This Matters

1. Glob `'.'` (or `*`, or `**/*`) ignores dotfiles – The old pattern skipped hidden files such as `.gitignore`, `.nojekyll`, or any project-specific dotfile, leaving them behind between deploys.
2. First-time deploy contamination – When gh-pages checks out a brand-new branch from the current branch, existing dotfiles are copied over, polluting the freshly created branch.

#### Impact

* Users with custom remove settings are unaffected.
* Users who relied on the old “keep dotfiles” behavior (expected to be rare) will now see those files removed; they can keep the old behavior by explicitly setting remove.

#### Future Work

* Consider creating the gh-pages branch from an empty tree during the very first deploy to avoid copying unrelated files at all—this can be explored in a separate PR.

#### References

* Shell globbing cheat sheet – <https://github.com/micromatch/micromatch#matching-features>
