### PR TITLE
fix: support `pushurl` remote config

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -199,8 +199,7 @@ Git.prototype.push = function (remote, branch, force) {
  * @return {Promise<string>} A promise for the remote URL.
  */
 Git.prototype.getRemoteUrl = function (remote) {
-  return this.exec('config', '--get', 'remote.' + remote + '.url')
-    .then((git) => {
+  const cleanOutput = (git) => {
       const repo = git.output && git.output.split(/[\n\r]/).shift();
       if (repo) {
         return repo;
@@ -209,7 +208,9 @@ Git.prototype.getRemoteUrl = function (remote) {
           'Failed to get repo URL from options or current directory.',
         );
       }
-    })
+    };
+  const pullURL = this.exec('config', '--get', 'remote.' + remote + '.url')
+    .then(cleanOutput)
     .catch((err) => {
       throw new Error(
         'Failed to get remote.' +
@@ -221,6 +222,7 @@ Git.prototype.getRemoteUrl = function (remote) {
           'or must be configured with the "repo" option).',
       );
     });
+  return Promise.all([pullURL, this.exec('config', '--get', 'remote.' + remote + '.pushurl').then(cleanOutput).catch(() => pullURL)]);
 };
 
 /**
@@ -235,7 +237,7 @@ Git.prototype.deleteRef = function (branch) {
 
 /**
  * Clone a repo into the given dir if it doesn't already exist.
- * @param {string} repo Repository URL.
+ * @param {[string, string]} repo Repository URL.
  * @param {string} dir Target directory.
  * @param {string} branch Branch name.
  * @param {options} options All options.
@@ -249,7 +251,7 @@ Git.clone = function clone(repo, dir, branch, options) {
       return fs.mkdirp(path.dirname(path.resolve(dir))).then(() => {
         const args = [
           'clone',
-          repo,
+          repo[0],
           dir,
           '--branch',
           branch,
@@ -264,14 +266,17 @@ Git.clone = function clone(repo, dir, branch, options) {
             // try again without branch or depth options
             return spawn(options.git, [
               'clone',
-              repo,
+              repo[0],
               dir,
               '--origin',
               options.remote,
             ]);
           })
           .then(() => new Git(dir, options.git));
-      });
+      }).then(repo[0] !== repo[1] ?
+        (g) => spawn(options.git, ['config', '--set', 'remote.' + remote + '.pushurl', repo[1]]).then(() => g) :
+        undefined
+      );
     }
   });
 };

--- a/lib/git.js
+++ b/lib/git.js
@@ -200,15 +200,15 @@ Git.prototype.push = function (remote, branch, force) {
  */
 Git.prototype.getRemoteUrl = function (remote) {
   const cleanOutput = (git) => {
-      const repo = git.output && git.output.split(/[\n\r]/).shift();
-      if (repo) {
-        return repo;
-      } else {
-        throw new Error(
-          'Failed to get repo URL from options or current directory.',
-        );
-      }
-    };
+    const repo = git.output && git.output.split(/[\n\r]/).shift();
+    if (repo) {
+      return repo;
+    } else {
+      throw new Error(
+        'Failed to get repo URL from options or current directory.',
+      );
+    }
+  };
   const pullURL = this.exec('config', '--get', 'remote.' + remote + '.url')
     .then(cleanOutput)
     .catch((err) => {
@@ -222,7 +222,12 @@ Git.prototype.getRemoteUrl = function (remote) {
           'or must be configured with the "repo" option).',
       );
     });
-  return Promise.all([pullURL, this.exec('config', '--get', 'remote.' + remote + '.pushurl').then(cleanOutput).catch(() => pullURL)]);
+  return Promise.all([
+    pullURL,
+    this.exec('config', '--get', 'remote.' + remote + '.pushurl')
+      .then(cleanOutput)
+      .catch(() => pullURL),
+  ]);
 };
 
 /**
@@ -248,35 +253,44 @@ Git.clone = function clone(repo, dir, branch, options) {
     if (exists) {
       return Promise.resolve(new Git(dir, options.git));
     } else {
-      return fs.mkdirp(path.dirname(path.resolve(dir))).then(() => {
-        const args = [
-          'clone',
-          repo[0],
-          dir,
-          '--branch',
-          branch,
-          '--single-branch',
-          '--origin',
-          options.remote,
-          '--depth',
-          options.depth,
-        ];
-        return spawn(options.git, args)
-          .catch((err) => {
-            // try again without branch or depth options
-            return spawn(options.git, [
-              'clone',
-              repo[0],
-              dir,
-              '--origin',
-              options.remote,
-            ]);
-          })
-          .then(() => new Git(dir, options.git));
-      }).then(repo[0] !== repo[1] ?
-        (g) => spawn(options.git, ['remote', 'set-url', '--push', options.remote, repo[1]], dir).then(() => g) :
-        undefined
-      );
+      return fs
+        .mkdirp(path.dirname(path.resolve(dir)))
+        .then(() => {
+          const args = [
+            'clone',
+            repo[0],
+            dir,
+            '--branch',
+            branch,
+            '--single-branch',
+            '--origin',
+            options.remote,
+            '--depth',
+            options.depth,
+          ];
+          return spawn(options.git, args)
+            .catch((err) => {
+              // try again without branch or depth options
+              return spawn(options.git, [
+                'clone',
+                repo[0],
+                dir,
+                '--origin',
+                options.remote,
+              ]);
+            })
+            .then(() => new Git(dir, options.git));
+        })
+        .then(
+          repo[0] !== repo[1]
+            ? (g) =>
+                spawn(
+                  options.git,
+                  ['remote', 'set-url', '--push', options.remote, repo[1]],
+                  dir,
+                ).then(() => g)
+            : undefined,
+        );
     }
   });
 };

--- a/lib/git.js
+++ b/lib/git.js
@@ -274,7 +274,7 @@ Git.clone = function clone(repo, dir, branch, options) {
           })
           .then(() => new Git(dir, options.git));
       }).then(repo[0] !== repo[1] ?
-        (g) => spawn(options.git, ['config', '--set', 'remote.' + remote + '.pushurl', repo[1]]).then(() => g) :
+        (g) => spawn(options.git, ['remote', 'set-url', '--push', options.remote, repo[1]], dir).then(() => g) :
         undefined
       );
     }

--- a/lib/git.js
+++ b/lib/git.js
@@ -82,13 +82,16 @@ class Git {
   }
   /**
    * Clone a repo into the given dir if it doesn't already exist.
-   * @param {[string, string]} repo Repository URLs.
+   * @param {string | [string, string]} repo Repository URLs.
    * @param {string} dir Target directory.
    * @param {string} branch Branch name.
    * @param {options} options All options.
    * @return {Promise<Git>} A promise.
    */
   static async clone(repo, dir, branch, options) {
+    if (typeof repo === 'string') {
+      repo = [repo, repo];
+    }
     const exists = await fs.exists(dir);
     if (exists) {
       return new Git(dir, options.git);

--- a/lib/index.js
+++ b/lib/index.js
@@ -132,13 +132,13 @@ exports.publish = function publish(basePath, config, callback) {
     getRepo(options)
       .then((repo) => {
         repoUrl = repo;
-        const clone = getCacheDir(repo);
-        log('Cloning %s into %s', repo, clone);
+        const clone = getCacheDir(repo[0]);
+        log('Cloning %s into %s', repo[0], clone);
         return Git.clone(repo, clone, options.branch, options);
       })
       .then((git) => {
         return git.getRemoteUrl(options.remote).then((url) => {
-          if (url !== repoUrl) {
+          if (url[0] !== repoUrl[0] || url[1] !== repoUrl[1]) {
             const message =
               'Remote url mismatch.  Got "' +
               url +

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ exports.getCacheDir = getCacheDir;
 
 async function getRepo(options) {
   if (options.repo) {
-    return [options.repo, options.repo];
+    return typeof options.repo === 'string' ? [options.repo, options.repo] : options.repo;
   }
   const git = new Git(process.cwd(), options.git);
   return git.getRemoteUrl(options.remote);

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ exports.getCacheDir = getCacheDir;
 
 async function getRepo(options) {
   if (options.repo) {
-    return options.repo;
+    return [options.repo, options.repo];
   }
   const git = new Git(process.cwd(), options.git);
   return git.getRemoteUrl(options.remote);

--- a/test/helper.js
+++ b/test/helper.js
@@ -92,7 +92,7 @@ function assertContentsMatch(dir, url, branch) {
     .then((root) => {
       const clone = path.join(root, 'repo');
       const options = {git: 'git', remote: 'origin', depth: 1};
-      return Git.clone(url, clone, branch, options);
+      return Git.clone([url, url], clone, branch, options);
     })
     .then((git) => {
       const comparison = compare(dir, git.cwd, {excludeFilter: '.git'});

--- a/test/helper.js
+++ b/test/helper.js
@@ -88,7 +88,7 @@ async function assertContentsMatch(dir, url, branch) {
   const root = await mkdtemp();
   const clone = path.join(root, 'repo');
   const options = {git: 'git', remote: 'origin', depth: 1};
-  const git = await Git.clone([url, url], clone, branch, options);
+  const git = await Git.clone(url, clone, branch, options);
   const comparison = compare(dir, git.cwd, {excludeFilter: '.git'});
   if (comparison.same) {
     return true;

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { pathToFileURL } = require('url');
 const chai = require('chai');
 const compare = require('dir-compare').compareSync;
 const fs = require('fs-extra');
@@ -73,7 +74,7 @@ async function setupRemote(fixtureName, options) {
   await new Git(remote).exec('init', '--bare');
   const remote_1 = remote;
   const git = new Git(dir);
-  const url = 'file://' + remote_1;
+  const url = pathToFileURL(remote_1).href;
   await git.exec('push', url, branch);
   return url;
 }
@@ -114,3 +115,4 @@ async function assertContentsMatch(dir, url, branch) {
 exports.assertContentsMatch = assertContentsMatch;
 exports.setupRemote = setupRemote;
 exports.setupRepo = setupRepo;
+exports.mkdtemp = mkdtemp;

--- a/test/integration/basic.spec.js
+++ b/test/integration/basic.spec.js
@@ -1,6 +1,8 @@
 const path = require('path');
+const { fileURLToPath, pathToFileURL } = require('url')
 const {beforeEach, describe, it} = require('mocha');
 const ghPages = require('../../lib/index.js');
+const Git = require('../../lib/git.js');
 const helper = require('../helper.js');
 
 const fixtures = path.join(__dirname, 'fixtures');
@@ -44,5 +46,24 @@ describe('basic usage', () => {
     };
     await ghPages.publish(local, options);
     await helper.assertContentsMatch(local, url, branch);
+  });
+
+  it('can push to a different URL', async () => {
+    const local = path.join(fixtures, fixtureName, 'local');
+    const expected = path.join(fixtures, fixtureName, 'expected');
+    const branch = 'gh-pages';
+
+    const pushURL = await helper.setupRemote(fixtureName, { branch });
+    const pullRepo = await helper.mkdtemp();
+    await new Git(pullRepo).exec('clone', '-b', branch, pushURL, '.');
+    const options = {
+      repo: [pathToFileURL(pullRepo).href, pushURL],
+      user: {
+        name: 'User Name',
+        email: 'user@email.com',
+      },
+    };
+    await ghPages.publish(local, options);
+    await helper.assertContentsMatch(expected, pushURL, branch);
   });
 });


### PR DESCRIPTION
I was trying to upgrade an old project from gh-pages 4.x to 6.x. Let's assume the following git configuration:

```console
$  git remote -v                   
origin  https://github.com/owner/repo.git (fetch)
origin  git@github.com:owner/repo.git (push)
```

I would expect `gh-pages` respect that configuration, i.e. pulling using the HTTPS URL (not auth needed for a public repo), and push using the authenticated SSH one. However, gh-pages tries to use the "fetch" one to push, which fails because it's not authenticated.